### PR TITLE
ghs: Improve handling of the -os_dir argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ matrix:
     # macOS clang
     - os: osx
       compiler: clang
+      osx_image: xcode10.2
       addons:
         homebrew:
           packages:

--- a/src/wrappers/ghs_wrapper.cpp
+++ b/src/wrappers/ghs_wrapper.cpp
@@ -19,12 +19,20 @@
 
 #include <wrappers/ghs_wrapper.hpp>
 
+#include <base/debug_utils.hpp>
 #include <base/file_utils.hpp>
 #include <base/unicode_utils.hpp>
 
 #include <stdexcept>
 
 namespace bcache {
+namespace {
+bool is_source_file(const std::string& arg) {
+  const auto ext = lower_case(file::get_extension(arg));
+  return ((ext == ".cpp") || (ext == ".cc") || (ext == ".cxx") || (ext == ".c"));
+}
+}  // namespace
+
 ghs_wrapper_t::ghs_wrapper_t(const string_list_t& args) : gcc_wrapper_t(args) {
 }
 
@@ -34,6 +42,42 @@ bool ghs_wrapper_t::can_handle_command() {
   return (cmd.find("ccarm") != std::string::npos) || (cmd.find("cxarm") != std::string::npos) ||
          (cmd.find("ccthumb") != std::string::npos) || (cmd.find("cxthumb") != std::string::npos) ||
          (cmd.find("ccintarm") != std::string::npos) || (cmd.find("cxintarm") != std::string::npos);
+}
+
+string_list_t ghs_wrapper_t::get_relevant_arguments() {
+  string_list_t filtered_args;
+
+  // The first argument is the compiler binary without the path.
+  filtered_args += file::get_file_part(m_args[0]);
+
+  // Note: We always skip the first arg since we have handled it already.
+  bool skip_next_arg = true;
+  for (auto arg : m_args) {
+    if (!skip_next_arg) {
+      // Does this argument specify a file (we don't want to hash those).
+      const bool is_arg_plus_file_name =
+          ((arg == "-I") || (arg == "-MF") || (arg == "-MT") || (arg == "-MQ") || (arg == "-o"));
+
+      // Generally unwanted argument (things that will not change how we go from preprocessed code
+      // to binary object files)?
+      const auto first_two_chars = arg.substr(0, 2);
+      const bool is_unwanted_arg =
+          ((first_two_chars == "-I") || (first_two_chars == "-D") || (first_two_chars == "-M") ||
+           (arg.substr(0, 8) == "-os_dir=") || is_source_file(arg));
+
+      if (is_arg_plus_file_name) {
+        skip_next_arg = true;
+      } else if (!is_unwanted_arg) {
+        filtered_args += arg;
+      }
+    } else {
+      skip_next_arg = false;
+    }
+  }
+
+  debug::log(debug::DEBUG) << "Filtered arguments: " << filtered_args.join(" ", true);
+
+  return filtered_args;
 }
 
 std::map<std::string, std::string> ghs_wrapper_t::get_relevant_env_vars() {
@@ -48,7 +92,27 @@ std::string ghs_wrapper_t::get_program_id() {
   // not exist (otherwise it will fail or actually perform the compilation), and then the output is
   // sent to stderr instead of stdout.
 
-  // Instead, we fall back to the default program ID logic.
-  return program_wrapper_t::get_program_id();
+  // Instead, we fall back to the default program ID logic (i.e. hash the program binary).
+  const auto program_version_info = program_wrapper_t::get_program_id();
+
+  // Try to retrieve the version information for the OS files.
+  std::string os_dir;
+  for (auto arg : m_args) {
+    if (arg.substr(0, 8) == "-os_dir=") {
+      os_dir = arg.substr(8);
+    }
+  }
+  std::string os_version_info;
+  if (!os_dir.empty()) {
+    // There should be a header file called ${OS_DIR}/INTEGRITY-include/INTEGRITY_version.h that
+    // contains version information.
+    const auto os_version_file =
+        file::append_path(file::append_path(os_dir, "INTEGRITY-include"), "INTEGRITY_version.h");
+    if (file::file_exists(os_version_file)) {
+      os_version_info = file::read(os_version_file);
+    }
+  }
+
+  return program_version_info + os_version_info;
 }
 }  // namespace bcache

--- a/src/wrappers/ghs_wrapper.hpp
+++ b/src/wrappers/ghs_wrapper.hpp
@@ -33,6 +33,7 @@ public:
   bool can_handle_command() override;
 
 private:
+  string_list_t get_relevant_arguments() override;
   std::map<std::string, std::string> get_relevant_env_vars() override;
   std::string get_program_id() override;
 };


### PR DESCRIPTION
1. Exclude the -os_dir argument from get_relevant_arguments. This
   increases the cache hit probability (especially for remote cache
   hits) since the -os_dir usually contains an absolute path which
   may be machine/user specific.

2. Extract OS version information (derive it via the -os_dir argument).
   This is a cheap operation and it reduces the risk of cache
   collisions (even though most of the target OS specific differences
   should be caught by the preprocess step).