### PR TITLE
gcc_wrapper: Handle dots in exe file name

### DIFF
--- a/src/wrappers/gcc_wrapper.cpp
+++ b/src/wrappers/gcc_wrapper.cpp
@@ -72,7 +72,9 @@ gcc_wrapper_t::gcc_wrapper_t(const string_list_t& args) : program_wrapper_t(args
 
 bool gcc_wrapper_t::can_handle_command() {
   // Is this the right compiler?
-  const auto cmd = lower_case(file::get_file_part(m_args[0], false));
+  // Note: We keep the file extension part to support version strings in the executable file name,
+  // such as "aarch64-unknown-nto-qnx7.0.0-g++".
+  const auto cmd = lower_case(file::get_file_part(m_args[0], true));
 
   // gcc?
   if ((cmd.find("gcc") != std::string::npos) || (cmd.find("g++") != std::string::npos)) {


### PR DESCRIPTION
Some GCC toolchains have complex file name with version numbers in them, such as aarch64-unknown-nto-qnx7.0.0-g++. These are now detected properly.