### PR TITLE
Trimmed run time dependencies on Linux

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -57,7 +57,7 @@ target_link_libraries(base md4 lz4)
 if(WIN32 OR MINGW)
   target_link_libraries(base userenv)
 elseif(OPENSSL_FOUND)
-  target_link_libraries(base ${OPENSSL_LIBRARIES})
+  target_link_libraries(base ${OPENSSL_CRYPTO_LIBRARIES})
   target_compile_definitions(base PRIVATE HAS_OPENSSL)
 endif()
 


### PR DESCRIPTION
buildcache uses OpenSSL for HMAC computations only, thus linking with
`libcrypto.so` is enough. Reduces run time dependencies of buildcache
binary from:

```
$ ldd ./buildcache
	linux-vdso.so.1 =>  (0x00007ffe0fe8b000)
	libpthread.so.0 => /usr/lib64/libpthread.so.0 (0x00007f06c66b3000)
	libssl.so.10 => /usr/lib64/libssl.so.10 (0x00007f06c6441000)
	libcrypto.so.10 => /usr/lib64/libcrypto.so.10 (0x00007f06c5fdf000)
	libdl.so.2 => /usr/lib64/libdl.so.2 (0x00007f06c5ddb000)
	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007f06c5ad4000)
	libm.so.6 => /usr/lib64/libm.so.6 (0x00007f06c57d2000)
	libgcc_s.so.1 => /usr/lib64/libgcc_s.so.1 (0x00007f06c55bc000)
	libc.so.6 => /usr/lib64/libc.so.6 (0x00007f06c51ef000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f06c68cf000)
	libgssapi_krb5.so.2 => /usr/lib64/libgssapi_krb5.so.2 (0x00007f06c4fa2000)
	libkrb5.so.3 => /usr/lib64/libkrb5.so.3 (0x00007f06c4cb9000)
	libcom_err.so.2 => /usr/lib64/libcom_err.so.2 (0x00007f06c4ab5000)
	libk5crypto.so.3 => /usr/lib64/libk5crypto.so.3 (0x00007f06c4882000)
	libz.so.1 => /usr/lib64/libz.so.1 (0x00007f06c466c000)
	libkrb5support.so.0 => /usr/lib64/libkrb5support.so.0 (0x00007f06c445c000)
	libkeyutils.so.1 => /usr/lib64/libkeyutils.so.1 (0x00007f06c4258000)
	libresolv.so.2 => /usr/lib64/libresolv.so.2 (0x00007f06c403f000)
	libselinux.so.1 => /usr/lib64/libselinux.so.1 (0x00007f06c3e18000)
	libpcre.so.1 => /usr/lib64/libpcre.so.1 (0x00007f06c3bb6000)
```

to:

```
$ ldd ./buildcache
	linux-vdso.so.1 =>  (0x00007fff463c3000)
	libpthread.so.0 => /usr/lib64/libpthread.so.0 (0x00007f316c689000)
	libcrypto.so.10 => /usr/lib64/libcrypto.so.10 (0x00007f316c227000)
	libdl.so.2 => /usr/lib64/libdl.so.2 (0x00007f316c023000)
	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007f316bd1c000)
	libm.so.6 => /usr/lib64/libm.so.6 (0x00007f316ba1a000)
	libgcc_s.so.1 => /usr/lib64/libgcc_s.so.1 (0x00007f316b804000)
	libc.so.6 => /usr/lib64/libc.so.6 (0x00007f316b437000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f316c8a5000)
	libz.so.1 => /usr/lib64/libz.so.1 (0x00007f316b221000)
```