### PR TITLE
Added HASH_VERSION prefix to generated hashes to mirror the gcc wrapper.

### DIFF
--- a/src/wrappers/ghs_wrapper.cpp
+++ b/src/wrappers/ghs_wrapper.cpp
@@ -27,6 +27,9 @@
 
 namespace bcache {
 namespace {
+// Tick this to a new number if the format has changed in a non-backwards-compatible way.
+const std::string HASH_VERSION = "1";
+
 bool is_source_file(const std::string& arg) {
   const auto ext = lower_case(file::get_extension(arg));
   return ((ext == ".cpp") || (ext == ".cc") || (ext == ".cxx") || (ext == ".c"));
@@ -113,6 +116,6 @@ std::string ghs_wrapper_t::get_program_id() {
     }
   }
 
-  return program_version_info + os_version_info;
+  return HASH_VERSION + program_version_info + os_version_info;
 }
 }  // namespace bcache

--- a/src/wrappers/msvc_wrapper.cpp
+++ b/src/wrappers/msvc_wrapper.cpp
@@ -29,6 +29,9 @@
 
 namespace bcache {
 namespace {
+// Tick this to a new number if the format has changed in a non-backwards-compatible way.
+const std::string HASH_VERSION = "1";
+
 bool is_source_file(const std::string& arg) {
   const auto ext = lower_case(file::get_extension(arg));
   return ((ext == ".cpp") || (ext == ".cc") || (ext == ".cxx") || (ext == ".c"));
@@ -193,7 +196,7 @@ std::string msvc_wrapper_t::get_program_id() {
     throw std::runtime_error("Unable to get the compiler version information string.");
   }
 
-  return result.std_err;
+  return HASH_VERSION + result.std_err;
 }
 
 std::map<std::string, std::string> msvc_wrapper_t::get_build_files() {


### PR DESCRIPTION
The GHS and MSVC wrappers did not prefix the program ID with `HASH_VERSION` as the GCC wrapper did. This pull request adds it in order to increase consistency between wrappers, and to service future updates.

I have left the Lua wrapper alone, as I have assumed that the author will implement that themselves when overriding `get_program_id()`.