### PR TITLE
handle Windows drive letters

### DIFF
--- a/src/base/file_utils.cpp
+++ b/src/base/file_utils.cpp
@@ -451,6 +451,12 @@ void remove_dir(const std::string& path, const bool ignore_errors) {
 
 bool dir_exists(const std::string& path) {
 #ifdef _WIN32
+  // Do a quick check if this is a drive letter and assume it exists. For performance reasons
+  // do not invoke Win32 APIs to verify the volume etc.
+  if (path.size() == 2 && path[1] == ':') {
+    return true;
+  }
+
   struct __stat64 buffer;
   const auto success = (_wstat64(utf8_to_ucs2(path).c_str(), &buffer) == 0);
   return success && S_ISDIR(buffer.st_mode);

--- a/src/base/file_utils_test.cpp
+++ b/src/base/file_utils_test.cpp
@@ -114,14 +114,14 @@ TEST_CASE("append_path produces expected results") {
     CHECK_EQ(result.size(), expected_size);
   }
 
-  SUBCASE("En empty dir part results in the file part alone") {
+  SUBCASE("An empty dir part results in the file part alone") {
     const std::string part_1 = "";
     const std::string part_2 = "world";
     const std::string result = file::append_path(part_1, part_2);
     CHECK_EQ(result, part_2);
   }
 
-  SUBCASE("En empty file part results in the dir part alone") {
+  SUBCASE("An empty file part results in the dir part alone") {
     const std::string part_1 = "hello";
     const std::string part_2 = "";
     const std::string result = file::append_path(part_1, part_2);
@@ -144,6 +144,14 @@ TEST_CASE("get_dir_part produces expected results") {
     CHECK_EQ(result.size(), 0);
   }
 }
+
+#ifdef _WIN32
+TEST_CASE("dir_exists produces expected results"){
+  SUBCASE("A Windows drive letter is assumed to exist.") {
+    CHECK_EQ(file::dir_exists("c:"), true);
+  }
+}
+#endif
 
 TEST_CASE("get_file_part produces expected results") {
   SUBCASE("The file is extracted when it exists") {


### PR DESCRIPTION
Without this fix buildcache cannot process a `BUILDCACHE_DIR` of a root folder like `d:\buildcache`, leading to an error message "Unable to create directory". The new testcase will also fail without the fix.

The fix checks on a Windows system if the found slash comes right after a colon, which is in Windows paths only allowed for drive letters. In that case, no parent dir is returned.

**How to reproduce error**

* Windows 10, 64 bit
* `BUILDCACHE_DIR=d:\.buildcache`

Run buildcache from `master` branch with any compiler command. Leads to this error in log:

```
BuildCache[12196] (ERROR) Unexpected error: Unable to create directory d:
```

Call stack at error message:

```
>	bcache::file::create_dir(const std::basic_string<char,std::char_traits<char>,std::allocator<char> > & path={...}) Line 412	C++
 	bcache::file::create_dir_with_parents(const std::basic_string<char,std::char_traits<char>,std::allocator<char> > & path={...}) Line 425	C++
 	bcache::file::create_dir_with_parents(const std::basic_string<char,std::char_traits<char>,std::allocator<char> > & path={...}) Line 424	C++
 	bcache::local_cache_t::local_cache_t() Line 138	C++
 	[External Code]	
 	bcache::program_wrapper_t::program_wrapper_t(const bcache::string_list_t & args={...}) Line 60	C++
 	bcache::gcc_wrapper_t::gcc_wrapper_t(const bcache::string_list_t & args={...}) Line 116	C++
 	`anonymous namespace'::find_suitable_wrapper(const bcache::string_list_t & args={...}) Line 95	C++
 	`anonymous namespace'::wrap_compiler_and_exit(int argc=25, const char * * argv=0x000002c3fef5e1b8) Line 313	C++
 	main(int argc=26, const char * * argv=0x000002c3fef5e1b0) Line 428	C++
```