### PR TITLE
prevent duplicate backslashes on Windows

### DIFF
--- a/src/base/string_list.hpp
+++ b/src/base/string_list.hpp
@@ -197,7 +197,12 @@ private:
       if (c == '"') {
         escaped_arg += "\\\"";
       } else if (c == '\\') {
+#ifdef _WIN32
+        // On Windows a backslash has semantic meaning and does not require escaping.
+        escaped_arg += c;
+#else
         escaped_arg += "\\\\";
+#endif
       } else if (c == '$') {
         escaped_arg += "\\$";
         needs_quotes = true;


### PR DESCRIPTION
Addresses https://github.com/mbitsnbites/buildcache/issues/75 and fixes the preprocessing error mentioned there.