### PR TITLE
Create parent dirs before cache file copy (Greenhills) - rewritten

### DIFF
--- a/src/base/string_list.hpp
+++ b/src/base/string_list.hpp
@@ -158,6 +158,18 @@ public:
     return *this;
   }
 
+  string_list_t operator+(const std::string& str) const {
+    string_list_t result(*this);
+    result += str;
+    return result;
+  }
+
+  string_list_t operator+(const string_list_t& list) const {
+    string_list_t result(*this);
+    result += list;
+    return result;
+  }
+
   size_t size() const {
     return m_args.size();
   }

--- a/src/cache/cache.cpp
+++ b/src/cache/cache.cpp
@@ -51,14 +51,17 @@ int64_t get_total_entry_size(const cache_entry_t& entry,
 bool cache_t::lookup(const hasher_t::hash_t hash,
                      const std::map<std::string, expected_file_t>& expected_files,
                      const bool allow_hard_links,
+                     const bool create_target_dirs,
                      int& return_code) {
   // First try the local cache.
-  if (lookup_in_local_cache(hash, expected_files, allow_hard_links, return_code)) {
+  if (lookup_in_local_cache(
+          hash, expected_files, allow_hard_links, create_target_dirs, return_code)) {
     return true;
   }
 
   // Then try the remote cache.
-  if (lookup_in_remote_cache(hash, expected_files, allow_hard_links, return_code)) {
+  if (lookup_in_remote_cache(
+          hash, expected_files, allow_hard_links, create_target_dirs, return_code)) {
     return true;
   }
 
@@ -104,6 +107,7 @@ void cache_t::add(const hasher_t::hash_t hash,
 bool cache_t::lookup_in_local_cache(const hasher_t::hash_t hash,
                                     const std::map<std::string, expected_file_t>& expected_files,
                                     const bool allow_hard_links,
+                                    const bool create_target_dirs,
                                     int& return_code) {
   PERF_START(CACHE_LOOKUP);
   // Note: The lookup will give us a lock file that is locked until we go out of scope.
@@ -123,6 +127,11 @@ bool cache_t::lookup_in_local_cache(const hasher_t::hash_t hash,
     const auto& target_path = expected_files.at(file_id).path();
     debug::log(debug::INFO) << "Cache hit (" << hash.as_string() << "): " << file_id << " => "
                             << target_path;
+
+    if (create_target_dirs) {
+      file::create_dir_with_parents(file::get_dir_part(target_path));
+    }
+
     const auto is_compressed = (cached_entry.compression_mode() == cache_entry_t::comp_mode_t::ALL);
     m_local_cache.get_file(hash, file_id, target_path, is_compressed, allow_hard_links);
   }
@@ -139,6 +148,7 @@ bool cache_t::lookup_in_local_cache(const hasher_t::hash_t hash,
 bool cache_t::lookup_in_remote_cache(const hasher_t::hash_t hash,
                                      const std::map<std::string, expected_file_t>& expected_files,
                                      const bool allow_hard_links,
+                                     const bool create_target_dirs,
                                      int& return_code) {
   // Start by trying to connect to the remote cache.
   if (!m_remote_cache.connect()) {
@@ -162,6 +172,11 @@ bool cache_t::lookup_in_remote_cache(const hasher_t::hash_t hash,
     const auto& target_path = expected_files.at(file_id).path();
     debug::log(debug::INFO) << "Remote cache hit (" << hash.as_string() << "): " << file_id
                             << " => " << target_path;
+
+    if (create_target_dirs) {
+      file::create_dir_with_parents(file::get_dir_part(target_path));
+    }
+
     const auto is_compressed = (cached_entry.compression_mode() == cache_entry_t::comp_mode_t::ALL);
     m_remote_cache.get_file(hash, file_id, target_path, is_compressed);
   }

--- a/src/cache/cache.hpp
+++ b/src/cache/cache.hpp
@@ -38,11 +38,13 @@ public:
   /// @param expected_files Paths to the actual files in the local file system (map from file ID to
   /// an expected file descriptor).
   /// @param allow_hard_links True if we are allowed to use hard links.
+  /// @param create_target_dirs True if the target directory of the cached file must be created.
   /// @param[out] return_code The return code of the program.
   /// @returns true if we had a cache hit, otherwise false.
   bool lookup(const hasher_t::hash_t hash,
               const std::map<std::string, expected_file_t>& expected_files,
               const bool allow_hard_links,
+              const bool create_target_dirs,
               int& return_code);
 
   /// @brief Add a new entry to the cache(s).
@@ -60,11 +62,13 @@ private:
   bool lookup_in_local_cache(const hasher_t::hash_t hash,
                              const std::map<std::string, expected_file_t>& expected_files,
                              const bool allow_hard_links,
+                             const bool create_target_dirs,
                              int& return_code);
 
   bool lookup_in_remote_cache(const hasher_t::hash_t hash,
                               const std::map<std::string, expected_file_t>& expected_files,
                               const bool allow_hard_links,
+                              const bool create_target_dirs,
                               int& return_code);
 
   local_cache_t m_local_cache;

--- a/src/wrappers/ghs_wrapper.cpp
+++ b/src/wrappers/ghs_wrapper.cpp
@@ -133,4 +133,9 @@ std::string ghs_wrapper_t::get_program_id() {
 
   return HASH_VERSION + program_version_info + os_version_info;
 }
+
+string_list_t ghs_wrapper_t::get_capabilities() {
+  // GHS compilers implicitly create target directories for object files.
+  return gcc_wrapper_t::get_capabilities() + "create_target_dirs";
+}
 }  // namespace bcache

--- a/src/wrappers/ghs_wrapper.hpp
+++ b/src/wrappers/ghs_wrapper.hpp
@@ -36,6 +36,7 @@ private:
   string_list_t get_relevant_arguments() override;
   std::map<std::string, std::string> get_relevant_env_vars() override;
   std::string get_program_id() override;
+  string_list_t get_capabilities() override;
 };
 }  // namespace bcache
 

--- a/src/wrappers/program_wrapper.cpp
+++ b/src/wrappers/program_wrapper.cpp
@@ -115,7 +115,11 @@ bool program_wrapper_t::handle_command(int& return_code) {
     PERF_STOP(GET_BUILD_FILES);
 
     // Look up the entry in the cache(s).
-    if (m_cache.lookup(hash, expected_files, allow_hard_links, return_code)) {
+    if (m_cache.lookup(hash,
+                       expected_files,
+                       allow_hard_links,
+                       capabilites.create_target_dirs(),
+                       return_code)) {
       return true;
     } else {
       debug::log(debug::INFO) << "Cache miss (" << hash.as_string() << ")";

--- a/src/wrappers/program_wrapper.cpp
+++ b/src/wrappers/program_wrapper.cpp
@@ -41,14 +41,21 @@ public:
     return m_hard_links;
   }
 
+  bool create_target_dirs() const {
+    return m_create_target_dirs;
+  }
+
 private:
   bool m_hard_links = false;
+  bool m_create_target_dirs = false;
 };
 
 capabilities_t::capabilities_t(const string_list_t& cap_strings) {
   for (const auto& str : cap_strings) {
     if (str == "hard_links") {
       m_hard_links = true;
+    } else if (str == "create_target_dirs") {
+      m_create_target_dirs = true;
     } else {
       debug::log(debug::ERROR) << "Invalid capability string: " << str;
     }


### PR DESCRIPTION
This is a history-rewritten version of #91 