### PR TITLE
MSBuild support

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -94,3 +94,20 @@ Example:
 $ BUILDCACHE_REMOTE=s3://my-minio-server:9000/my-buildcache-bucket BUILDCACHE_S3_ACCESS="ABCDEFGHIJKL01234567" BUILDCACHE_S3_SECRET="sOMloNgSecretKeyThatsh0uldnotBeshownatAll" buildcache g++ -c -O2 hello.cpp -o hello.o
 ```
 
+## Using with Visual Studio / MSBuild
+
+For usage with command line MSBuild or in Visual Studio, BuildCache must be configured to be compatible with MSBuild's FileTracker.
+
+* Set `BUILDCACHE_DIR` environment variable to `C:\ProgramData\buildcache`.
+  * or [one of the folders ignored by file tracking](https://github.com/microsoft/msbuild/blob/9eb5d09e6cd262375e37a15a779d56ab274167c8/src/Utilities/TrackedDependencies/FileTracker.cs#L208).
+* Create a symlink named `cl.exe` pointing to your `buildcache.exe`.
+
+Additionally, several default project settings have to be changed:
+
+* Change object file names from `$(IntDir)` to `$(IntDir)%(Filename).obj` to get one compiler invocation per source file.
+  * Can be set by opening a project's properties, then *Configuration Properties*, *C/C++*, *Output Files* page, *Object File Name* setting,
+  * Alternatively define the `<ObjectFileName>` property inside the `<ClCompile>` ItemDefinitionGroup in your `vcxproj` file.
+* Since the previous step turns off compiler level parallelism, restore performance using [`MultiToolTask`](https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/).
+  * Can be turned on using the `<UseMultiToolTask>` property inside the `"Globals"` PropertyGroup in your `vcxproj`.
+* Set `<CLToolExe>` property to the symlink created previously.
+  * Also placed inside the `"Globals"` PropertyGroup in your `vcxproj`.

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -33,6 +33,7 @@ set(BASE_SRC
   serializer_utils.cpp
   serializer_utils.hpp
   string_list.hpp
+  string_list.cpp
   unicode_utils.cpp
   unicode_utils.hpp
   )

--- a/src/base/env_utils.cpp
+++ b/src/base/env_utils.cpp
@@ -74,6 +74,17 @@ scoped_set_env_t::~scoped_set_env_t() {
   }
 }
 
+scoped_unset_env_t::scoped_unset_env_t(const std::string& name)
+    : m_name(name), m_old_env_var(name) {
+  unset_env(name);
+}
+
+scoped_unset_env_t::~scoped_unset_env_t() {
+  if (m_old_env_var) {
+    set_env(m_name, m_old_env_var.as_string());
+  }
+}
+
 bool env_defined(const std::string& env_var) {
 #if defined(_WIN32)
   const auto env_var_w = utf8_to_ucs2(env_var);

--- a/src/base/env_utils.hpp
+++ b/src/base/env_utils.hpp
@@ -67,6 +67,21 @@ private:
   env_var_t m_old_env_var;
 };
 
+/// @brief A class for temporarily clearing an environment variable.
+class scoped_unset_env_t {
+public:
+  /// @brief Temporarily clear an environment variable.
+  /// @param name The name of the environment variable.
+  scoped_unset_env_t(const std::string& name);
+
+  /// @brief Restore the environment variable to its old value.
+  ~scoped_unset_env_t();
+
+private:
+  std::string m_name;
+  env_var_t m_old_env_var;
+};
+
 /// @brief Check if the named environment variable is defined.
 /// @param env_var Name of the environment variable.
 /// @returns true if the environment variable was defined, otherwise false.

--- a/src/base/file_utils.cpp
+++ b/src/base/file_utils.cpp
@@ -563,19 +563,21 @@ void link_or_copy(const std::string& from_path, const std::string& to_path) {
   success = (link(from_path.c_str(), to_path.c_str()) == 0);
 #endif
 
-  // Touch the file to update the modification time.
-  if (success) {
-#ifdef _WIN32
-    success = (_wutime64(utf8_to_ucs2(to_path).c_str(), nullptr) == 0);
-#else
-    success = (utime(to_path.c_str(), nullptr) == 0);
-#endif
-  }
-
   // If the hard link failed, make a full copy instead.
   if (!success) {
     debug::log(debug::DEBUG) << "Hard link failed - copying instead.";
     copy(from_path, to_path);
+  }
+}
+
+void touch(const std::string& path) {
+#ifdef _WIN32
+  bool success = (_wutime64(utf8_to_ucs2(path).c_str(), nullptr) == 0);
+#else
+  bool success = (utime(path.c_str(), nullptr) == 0);
+#endif
+  if (!success) {
+    throw std::runtime_error("Unable to touch the file.");
   }
 }
 

--- a/src/base/file_utils.hpp
+++ b/src/base/file_utils.hpp
@@ -226,6 +226,11 @@ void copy(const std::string& from_path, const std::string& to_path);
 /// @throws runtime_error if the operation could not be completed.
 void link_or_copy(const std::string& from_path, const std::string& to_path);
 
+/// @brief Touch the file to update the modification time.
+/// @param path The path to the file.
+/// @throws runtime_error if the operation could not be completed.
+void touch(const std::string& path);
+
 /// @brief Read a file into a string.
 /// @param path The path to the file.
 /// @returns the contents of the file as a string.

--- a/src/base/string_list.cpp
+++ b/src/base/string_list.cpp
@@ -1,0 +1,197 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2018 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#include <base/string_list.hpp>
+
+#include <base/unicode_utils.hpp>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <shellapi.h>
+#endif
+
+namespace bcache {
+
+string_list_t::string_list_t(const std::string& str, const std::string& delimiter) {
+  std::string::size_type current_str_start = 0u;
+  while (current_str_start < str.size()) {
+    const auto pos = str.find(delimiter, current_str_start);
+    if (pos == std::string::npos) {
+      m_args.emplace_back(str.substr(current_str_start));
+      current_str_start = str.size();
+    } else {
+      m_args.emplace_back(str.substr(current_str_start, pos - current_str_start));
+      current_str_start = pos + 1;
+    }
+  }
+}
+
+string_list_t string_list_t::split_args(const std::string& cmd) {
+  string_list_t args;
+
+#ifdef _WIN32
+  std::wstring wcmd = utf8_to_ucs2(cmd);
+  int argc;
+  wchar_t** argv = CommandLineToArgvW(wcmd.data(), &argc);
+  for (int i = 0; i < argc; ++i) {
+    args += ucs2_to_utf8(argv[i]);
+  }
+
+#else
+  std::string arg;
+  auto is_inside_quote = false;
+  auto has_arg = false;
+  char last_char = 0;
+  for (auto& chr : cmd) {
+    const auto is_space = (chr == ' ');
+    const auto is_quote = (chr == '\"') && (last_char != '\\');
+
+    if (is_quote) {
+      is_inside_quote = !is_inside_quote;
+    }
+
+    // Start of a new argument?
+    if ((!has_arg) && (!is_space)) {
+      has_arg = true;
+    }
+
+    // Append this char to the argument string?
+    if ((is_inside_quote || !is_space) && !is_quote) {
+      arg += chr;
+    }
+
+    // End of argument?
+    if (has_arg && is_space && !is_inside_quote) {
+      args += unescape_arg(arg);
+      arg.clear();
+      has_arg = false;
+    }
+
+    last_char = chr;
+  }
+
+  if (has_arg) {
+    args += unescape_arg(arg);
+  }
+
+#endif
+  return args;
+}
+
+std::string string_list_t::join(const std::string& separator,
+                                               const bool escape) const {
+  std::string result;
+  for (auto arg : m_args) {
+    const auto escaped_arg = escape ? escape_arg(arg) : arg;
+    if (result.empty()) {
+      result += escaped_arg;
+    } else {
+      result += (separator + escaped_arg);
+    }
+  }
+  return result;
+}
+
+inline std::string bcache::string_list_t::escape_arg(const std::string& arg) {
+  std::string escaped_arg;
+  bool needs_quotes = false;
+
+#ifdef _WIN32
+  // These escaping rules try to match parsing rules of Windows programs, e.g. as outlined here:
+  // http://www.windowsinspired.com/how-a-windows-programs-splits-its-command-line-into-individual-arguments/
+  // "[..] backslashes are interpreted literally (except when they precede a double quote
+  // character)".
+  int backslashes = 0;
+  for (auto c : arg) {
+    if (c == '\\') {
+      ++backslashes;
+    } else {
+      if (c == '\"') {
+        for (int i = 0; i <= backslashes; ++i) {
+          escaped_arg += '\\';
+        }
+      }
+      backslashes = 0;
+    }
+
+    escaped_arg += c;
+
+    if (c == ' ' || c == '\t') {
+      needs_quotes = true;
+    }
+  }
+
+  if (needs_quotes) {
+    for (int i = 0; i < backslashes; ++i) {
+      escaped_arg += '\\';
+    }
+  }
+
+#else
+  // These escaping rules try to match the most common Un*x shell conventions, e.g. as outlined
+  // here: http://faculty.salina.k-state.edu/tim/unix_sg/shell/metachar.html
+  for (auto c : arg) {
+    if (c == '"') {
+      escaped_arg += "\\\"";
+    } else if (c == '\\') {
+      escaped_arg += "\\\\";
+    } else if (c == '$') {
+      escaped_arg += "\\$";
+      needs_quotes = true;
+    } else if (c == '`') {
+      escaped_arg += "\\`";
+      needs_quotes = true;
+    } else {
+      if (c == ' ' || c == '&' || c == ';' || c == '>' || c == '<' || c == '|' || c == '(' ||
+          c == ')' || c == '*' || c == '#') {
+        needs_quotes = true;
+      }
+      escaped_arg += c;
+    }
+  }
+#endif
+
+  // Do we need to surround with quotes?
+  if (needs_quotes) {
+    escaped_arg = std::string("\"") + escaped_arg + std::string("\"");
+  }
+
+  return escaped_arg;
+}
+
+inline std::string bcache::string_list_t::unescape_arg(const std::string& arg) {
+  std::string unescaped_arg;
+
+  auto is_escaped = false;
+  for (auto c : arg) {
+    if ((c == '\\') && !is_escaped) {
+      is_escaped = true;
+    } else {
+      // TODO(m): We should handle different escape codes. The current solution at least works for
+      // converting \\ -> \ and \" -> ".
+      unescaped_arg += c;
+      is_escaped = false;
+    }
+  }
+
+  return unescaped_arg;
+}
+
+}  // namespace bcache

--- a/src/base/string_list_test.cpp
+++ b/src/base/string_list_test.cpp
@@ -75,7 +75,11 @@ TEST_CASE("Command line argument parsing works correctly") {
     string_list_t list = string_list_t::split_args(cmd);
     CHECK_EQ(list.size(), 2);
     CHECK_EQ(list[0], "hello");
+#ifdef _WIN32
+    CHECK_EQ(list[1], "beautiful \\\\ \"  world");
+#else
     CHECK_EQ(list[1], "beautiful \\ \"  world");
+#endif
   }
 }
 

--- a/src/cache/local_cache.cpp
+++ b/src/cache/local_cache.cpp
@@ -368,6 +368,10 @@ void local_cache_t::get_file(const hasher_t::hash_t& hash,
   } else {
     file::copy(source_path, target_path);
   }
+
+  // Touch retrieved file to ensure that the file timestamp is up to date, 
+  // and that it is picked up by build system file trackers such as MSBuild.
+  file::touch(target_path);
 }
 
 void local_cache_t::perform_housekeeping() {


### PR DESCRIPTION
This PR adds support for MSBuild, used from command line or from Visual Studio. The reasons for several changes we applied are detailed here, as well as an overview of the steps needed to get it running in a Visual Studio project. We've tested the setup focusing on `x64` builds with Visual Studio Community 2019 v16.6.0, with platform toolset v142.

Related issue: https://github.com/mbitsnbites/buildcache/issues/96.

## Changes

### 1. MSVC version querying
When `cl.exe` is called with 0 arguments it writes its 'logo string' to `stderr`. This 'logo string' is used in the cache keys. However, when run from Visual Studio, buildcache fails to query the version of `cl.exe`, because its `stderr` output is captured by the Visual Studio Output Window.

We obtain this part of the hash based on the path of `cl.exe` instead, as it contains the version and platform by default. E.g. `C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.26.28801\bin\Hostx64\x64\cl.exe` for the default installation location in our setup.

### 2. Command line argument splitting and joining
Windows CMD and programs use different rules from UNIX shells for escaping characters and splitting arguments. It's important to consider this when dealing with response files, and when invoking `cl.exe` using `CreateProcessW()`.

The Windows API gives a reference implementation for splitting the arguments, in the form of [`CommandLineToArgvW()`](https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-commandlinetoargvw) function. Unfortunately no inverse function is provided, therefore we implemented it manually.

For the specifics of command line parsing, refer to these insightful articles on Windows Inspired:
* [A Better Way To Understand Quoting and Escaping of Windows Command Line Arguments](http://www.windowsinspired.com/understanding-the-command-line-string-and-arguments-received-by-a-windows-program/)
* [How a Windows Program Splits Its Command Line Into Individual Arguments](http://www.windowsinspired.com/how-a-windows-programs-splits-its-command-line-into-individual-arguments/)

### 3. UTF-16 response files
MSBuild may write its response files [in UTF-16 with BOM or in ANSI](https://docs.microsoft.com/en-us/cpp/build/reference/unicode-support-in-the-compiler-and-linker?view=vs-2019#linker-response-files-and-def-files) encoding - UTF-16 LE in practice in all our tests on Windows 10. The file reader checks the first two bytes for [UTF-16 BOM](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-16). Files without a UTF-16 BOM are assumed to be in UTF-8. 

### 4. Dealing with MSBuild FileTracker
MSBuild [CL Task](https://docs.microsoft.com/en-gb/visualstudio/msbuild/cl-task?view=vs-2019) tracks all file reads and writes during the compilation of a source file, and stores them in `*.tlog` files - these serve as dependency descriptions for each source, used by MSBuild's "minimal rebuild" feature.

When retrieving an `.obj` file from the cache storage, buildcache first copies to a `.tmp` temporary, then moves to the target path. MSBuild's [FileTracker](https://docs.microsoft.com/en-us/visualstudio/msbuild/file-tracking?view=vs-2019) somehow misses this operation, and does not register the `.obj` from the cache as a write dependency of a compilation. Due to the incomplete/incorrect resulting `*write.*.tlog` files, the "minimal rebuild" feature becomes more fragile. For example adding a new source file to a project would trigger a full rebuild of that project. Same with deleted `.obj` files.

We solved this by opening the result file after a successful move. The Windows API call is then noticed by FileTracker, even if no actual writes are done to said file. There's another note about file tracking, see later in Setup.

### 5. Resolving symlink paths on Windows
Completing a *TODO* here, `resolve_path()` now returns the target path of symlinks on Windows too, using [`GetFinalPathNameByHandleW()`](https://docs.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getfinalpathnamebyhandlew). Necessary for the "symlink invocation" feature.

## Setup
* Set object file names from `$(IntDir)` to `$(IntDir)%(Filename).obj`.
  * This changes `/Fo` parameter from a folder to a file path, and we get one `cl.exe` invocation per source file.
* Since the previous step turns off compiler level parallelism, performance has to be restored using `MultiToolTask`
  * See the article [Improved Parallelism in MSBuild](https://devblogs.microsoft.com/cppblog/improved-parallelism-in-msbuild/).
* Set `BUILDCACHE_DIR` environment variable to `C:\ProgramData\buildcache`
  * or [one of the folders ignored by file tracking](https://github.com/microsoft/msbuild/blob/9eb5d09e6cd262375e37a15a779d56ab274167c8/src/Utilities/TrackedDependencies/FileTracker.cs#L208).
* Create a symlink named `cl.exe` pointing to your `buildcache.exe`
  * A seemingly easier alternative is to send `cl.exe` calls through a `.bat` file, but in our tests it didn't play nicely with file tracking. Symlink invocation has no such issue.
* Set `CLToolExe` global property to the symlink created in the previous step
