### PR TITLE
gcc: Support response files

### DIFF
--- a/src/wrappers/gcc_wrapper.hpp
+++ b/src/wrappers/gcc_wrapper.hpp
@@ -37,6 +37,13 @@ protected:
   std::map<std::string, std::string> get_relevant_env_vars() override;
   std::string get_program_id() override;
   std::map<std::string, expected_file_t> get_build_files() override;
+
+  string_list_t m_resolved_args;
+
+private:
+  void resolve_args() override;
+  string_list_t parse_args(const string_list_t& args);
+  string_list_t parse_response_file(const std::string& filename);
 };
 }  // namespace bcache
 #endif  // BUILDCACHE_GCC_WRAPPER_HPP_


### PR DESCRIPTION
If msvc arguments include one or more response files (an argument of
'@filename'), open the file and add its contents to the parsed
arguments.

Issue: 8