### PR TITLE
Fix capturing cl.exe output when started inside Visual Studio

### DIFF
--- a/src/wrappers/msvc_wrapper.hpp
+++ b/src/wrappers/msvc_wrapper.hpp
@@ -38,6 +38,7 @@ private:
   std::map<std::string, std::string> get_relevant_env_vars() override;
   std::string get_program_id() override;
   std::map<std::string, expected_file_t> get_build_files() override;
+  sys::run_result_t run_for_miss() override;
 
   string_list_t m_resolved_args;
 };


### PR DESCRIPTION
Amendment to PR https://github.com/mbitsnbites/buildcache/pull/114 which introduced MSBuild support.

As discussed there, `VS_UNICODE_OUTPUT` enviroment variable controls whether `cl.exe` sends certain output directly to the IDE process instead of writing to `stdout`/`stderr` which intend to capture. I was under the wrong assumption that it only affects `stderr` messages, and [I stated](https://github.com/mbitsnbites/buildcache/pull/114#discussion_r451620672):
> Regulary, upon a successful compilation, cl.exe outputs the file name on stdout - **which BuildCache correctly captures**.

The highlighted part is unfortunately incorrect, BuildCache didn't capture the printed file name. This fix addresses that. 

(Appearently, all output is redirected, except where docs say otherwise - i.e. [`/EP`](https://docs.microsoft.com/en-us/cpp/build/reference/ep-preprocess-to-stdout-without-hash-line-directives?view=vs-2019) preprocess is meant to output to `stdout`, which it does, even when called from inside Visual Studio).
