### PR TITLE
added new interface method get_relevant_external_files

### DIFF
--- a/doc/lua.md
+++ b/doc/lua.md
@@ -38,6 +38,7 @@ documentation):
 | preprocess_source () | The preprocessed source code (e.g. for C/C++) | An empty string |
 | get_relevant_arguments () | Arguments that can affect the build output | All arguments |
 | get_relevant_env_vars () | Environment variables that can affect the build output | An empty table |
+| get_relevant_external_files () | A list of external files that can affect program execution| An empty table |
 | get_program_id () | A unique program identification | The MD4 hash of the program binary |
 | get_build_files () | A table of build result files | An empty table |
 | run_for_miss () | A `sys::run_result_t` compatible table | *See note\** |

--- a/src/base/hasher.cpp
+++ b/src/base/hasher.cpp
@@ -59,6 +59,17 @@ void hasher_t::update_from_file(const std::string& path) {
 }
 
 
+void hasher_t::update_from_files(const string_list_t& paths) {
+  for(const auto& path : paths) {
+    if (file::file_exists(path)) {
+      update_from_file(path);
+    } else {
+      throw std::runtime_error("External file not found : " + path);
+    }
+  }
+}
+
+
 void hasher_t::update_from_file_deterministic(const std::string& path) {
   const auto file_data = file::read(path);
   if (is_ar_data(file_data)) {

--- a/src/base/hasher.hpp
+++ b/src/base/hasher.hpp
@@ -20,6 +20,8 @@
 #ifndef BUILDCACHE_HASHER_HPP_
 #define BUILDCACHE_HASHER_HPP_
 
+#include <base/string_list.hpp>
+
 #include <cstdint>
 #include <map>
 #include <string>
@@ -80,6 +82,11 @@ public:
   /// @param path Path to a file that contains the data to hash.
   /// @throws runtime_error if the operation could not be completed.
   void update_from_file(const std::string& path);
+
+  /// @brief Update the hash with more data.
+  /// @param paths list of paths to a files that contains the data to hash.
+  /// @throws runtime_error if the operation could not be completed.
+  void update_from_files(const string_list_t& paths);
 
   /// @brief Update the hash with more data.
   ///

--- a/src/wrappers/lua_wrapper.cpp
+++ b/src/wrappers/lua_wrapper.cpp
@@ -524,6 +524,14 @@ std::map<std::string, std::string> lua_wrapper_t::get_relevant_env_vars() {
   }
 }
 
+string_list_t lua_wrapper_t::get_relevant_external_files() {
+  if (m_runner.call("get_relevant_external_files")) {
+    return pop_string_list(m_runner.state());
+  } else {
+    return program_wrapper_t::get_relevant_external_files();
+  }
+}
+
 std::string lua_wrapper_t::get_program_id() {
   if (m_runner.call("get_program_id")) {
     return pop_string(m_runner.state());

--- a/src/wrappers/lua_wrapper.hpp
+++ b/src/wrappers/lua_wrapper.hpp
@@ -72,6 +72,7 @@ private:
   std::string preprocess_source() override;
   string_list_t get_relevant_arguments() override;
   std::map<std::string, std::string> get_relevant_env_vars() override;
+  string_list_t get_relevant_external_files() override;
   std::string get_program_id() override;
   std::map<std::string, expected_file_t> get_build_files() override;
   sys::run_result_t run_for_miss() override;

--- a/src/wrappers/program_wrapper.cpp
+++ b/src/wrappers/program_wrapper.cpp
@@ -91,10 +91,11 @@ bool program_wrapper_t::handle_command(int& return_code) {
     hasher.update(preprocess_source());
     PERF_STOP(PREPROCESS);
 
-    // Hash the (filtered) command line flags and environment variables.
+    // Hash the (filtered) command line flags, environment variables and external files.
     PERF_START(FILTER_ARGS);
     hasher.update(get_relevant_arguments().join(" ", true));
     hasher.update(get_relevant_env_vars());
+    hasher.update_from_files(get_relevant_external_files());
     PERF_STOP(FILTER_ARGS);
 
     // Hash the program identification (version string or similar).
@@ -197,6 +198,12 @@ std::map<std::string, std::string> program_wrapper_t::get_relevant_env_vars() {
   // Default: There are no relevant environment variables.
   std::map<std::string, std::string> env_vars;
   return env_vars;
+}
+
+string_list_t program_wrapper_t::get_relevant_external_files() {
+  // Default: There are no relevant external files.
+  string_list_t external_files;
+  return external_files;
 }
 
 std::string program_wrapper_t::get_program_id() {

--- a/src/wrappers/program_wrapper.hpp
+++ b/src/wrappers/program_wrapper.hpp
@@ -103,6 +103,15 @@ protected:
   /// affect program output.
   virtual std::map<std::string, std::string> get_relevant_env_vars();
 
+
+  /// @brief Get relevant external files path for hashing.
+  /// @returns list of relevant external files
+  /// @throws runtime_error if the request could not be completed.
+  ///
+  /// @note The purpose of this function is to create a list of external files that may
+  /// affect program output. (files that are not part of the command arguments)
+  virtual string_list_t get_relevant_external_files();
+
   /// @brief Get a string that uniquely identifies the program.
   /// @returns a program ID string.
   /// @throws runtime_error if the request could not be completed.


### PR DESCRIPTION
Beside caching c++ builds. Buildcache is capable of caching program execution.

We aim to use buildcache to cache ctest results. A test may depends on some external files (test data) or some runtime dependencies (DLL). 

This new interface **get_relevant_external_files** is used to take in consideration these files when hashing test results.