### PR TITLE
Quiet compile-time warnings in buildcache code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Ignore build folders.
 build
-
+.vs
+.vscode

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -2,4 +2,4 @@
 CMakeLists.txt.user
 .vscode
 build
-
+out


### PR DESCRIPTION
This splits `bcache::comp::compress` into functions by the compression type; it didn't seem like there was really that much code shared.