### PR TITLE
add compiler setting to override exe to search for

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -29,6 +29,7 @@ The following options control the behavior of BuildCache:
 | `BUILDCACHE_DISABLE` | `disable` | Disable caching (bypass BuildCache) | false |
 | `BUILDCACHE_ACCURACY` | `accuracy` | Caching accuracy (see below) | DEFAULT |
 | `BUILDCACHE_READ_ONLY` | `read_only` | Only read and use the cache without updating it | false |
+| `BUILDCACHE_IMPERSONATE` | `impersonate` | Explicitly set the executable to wrap | None |
 
 Note: Currently, only the TI C6x back end supports the `cache_link_commands`
 option.

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -43,6 +43,24 @@ BuildCache[52286] (DEBUG) Invoked as symlink: gcc
 …
 ```
 
+## Impersonating a wrapped tool
+
+Setting `BUILDACHE_IMPERSONATE` forces BuildCache to operate as a tool wrapper,
+using the value of the property as the tool to wrap. This allows pointing build
+systems directly at the buildcache executable instead of using symbolic links.
+Note that when this setting has a non-default value BuildCache commands cannot
+be used - since any arguments are always forwarded to the wrapped tool.
+
+For example:
+
+```cmd
+set BUILDACHE_IMPERSONATE=cl.exe
+rem Wraps "cl.exe -s", probably not desired!
+buildcache -s
+rem Wraps execution of "cl.exe /c hello.cpp"
+buildcache /c hello.cpp
+```
+
 ## Using with icecream
 
 [icecream](https://github.com/icecc/icecream) (or ICECC) is a tool for
@@ -101,6 +119,7 @@ For usage with command line MSBuild or in Visual Studio, BuildCache must be conf
 * Set `BUILDCACHE_DIR` environment variable to `C:\ProgramData\buildcache`.
   * or [one of the folders ignored by file tracking](https://github.com/microsoft/msbuild/blob/9eb5d09e6cd262375e37a15a779d56ab274167c8/src/Utilities/TrackedDependencies/FileTracker.cs#L208).
 * Create a symlink named `cl.exe` pointing to your `buildcache.exe`.
+  * Alternatively, set `BUILDCACHE_IMPERSONATE` to `cl.exe`.
 
 Additionally, several default project settings have to be changed:
 

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -42,6 +42,7 @@ std::string s_dir;
 std::string s_config_file;
 string_list_t s_lua_paths;
 std::string s_prefix;
+std::string s_impersonate;
 std::string s_remote;
 std::string s_s3_access;
 std::string s_s3_secret;
@@ -151,6 +152,14 @@ void load_from_file(const std::string& file_name) {
     const auto* node = cJSON_GetObjectItemCaseSensitive(root, "prefix");
     if (cJSON_IsString(node) && node->valuestring != nullptr) {
       s_prefix = std::string(node->valuestring);
+    }
+  }
+
+  // Get "impersonate".
+  {
+    const auto* node = cJSON_GetObjectItemCaseSensitive(root, "impersonate");
+    if (cJSON_IsString(node) && node->valuestring != nullptr) {
+      s_impersonate = std::string(node->valuestring);
     }
   }
 
@@ -366,6 +375,14 @@ void init() {
       }
     }
 
+    // Get the executable to impersonate from the environment.
+    {
+      const env_var_t impersonate_env("BUILDCACHE_IMPERSONATE");
+      if (impersonate_env) {
+        s_impersonate = impersonate_env.as_string();
+      }
+    }
+
     // Get the remote cache address from the environment.
     {
       const env_var_t remote_env("BUILDCACHE_REMOTE");
@@ -534,6 +551,10 @@ const string_list_t& lua_paths() {
 
 const std::string& prefix() {
   return s_prefix;
+}
+
+const std::string& impersonate() {
+  return s_impersonate;
 }
 
 const std::string& remote() {

--- a/src/config/configuration.hpp
+++ b/src/config/configuration.hpp
@@ -66,8 +66,11 @@ const std::string& config_file();
 /// @returns the Lua search paths.
 const string_list_t& lua_paths();
 
-/// @returns the compiler exectution prefix command.
+/// @returns the compiler execution prefix command.
 const std::string& prefix();
+
+/// @returns the executable to impersonate.
+const std::string& impersonate();
 
 /// @returns the remote cache service address.
 const std::string& remote();


### PR DESCRIPTION
This add json property `compiler` and env var `BUILDCACHE_COMPILER`, which will override the string which is searched for in `PATH` as the actual compiler executable. This removes the need to use a symlink (which IMO is handy on Windows).