### PR TITLE
msbuild: suppress filetracker as needed

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -96,10 +96,6 @@ $ BUILDCACHE_REMOTE=s3://my-minio-server:9000/my-buildcache-bucket BUILDCACHE_S3
 
 ## Using with Visual Studio / MSBuild
 
-For usage with command line MSBuild or in Visual Studio, BuildCache must be configured to be compatible with MSBuild's FileTracker.
-
-* Set `BUILDCACHE_DIR` environment variable to `C:\ProgramData\buildcache`.
-  * or [one of the folders ignored by file tracking](https://github.com/microsoft/msbuild/blob/9eb5d09e6cd262375e37a15a779d56ab274167c8/src/Utilities/TrackedDependencies/FileTracker.cs#L208).
 * Create a symlink named `cl.exe` pointing to your `buildcache.exe`.
 
 Additionally, several default project settings have to be changed:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include <base/unicode_utils.hpp>
 #include <cache/local_cache.hpp>
 #include <config/configuration.hpp>
+#include <sys/filetracker.hpp>
 #include <sys/perf_utils.hpp>
 #include <sys/sys_utils.hpp>
 #include <wrappers/ccc_analyzer_wrapper.hpp>
@@ -299,6 +300,7 @@ std::unique_ptr<bcache::program_wrapper_t> find_suitable_wrapper(
 
     // Is the caching mechanism disabled?
     if (bcache::config::disable()) {
+      bcache::filetracker::resume();
       // Bypass all the cache logic and call the intended command directly.
       auto result = bcache::sys::run(args, false);
       return_code = result.return_code;
@@ -342,6 +344,7 @@ std::unique_ptr<bcache::program_wrapper_t> find_suitable_wrapper(
 
       // Fall back to running the command as is.
       if (!was_wrapped) {
+        bcache::filetracker::resume();
         PERF_START(RUN_FOR_FALLBACK);
         auto result = bcache::sys::run_with_prefix(args, false);
         PERF_STOP(RUN_FOR_FALLBACK);

--- a/src/sys/CMakeLists.txt
+++ b/src/sys/CMakeLists.txt
@@ -18,11 +18,17 @@
 #---------------------------------------------------------------------------------------------------
 
 set(SYS_SRCS
+  filetracker.hpp
   perf_utils.cpp
   perf_utils.hpp
   sys_utils.cpp
   sys_utils.hpp
   )
+if(WIN32 OR MINGW)
+  list(APPEND SYS_SRCS
+    filetracker.cpp
+    )
+endif()
 
 add_library(sys ${SYS_SRCS})
 target_link_libraries(sys base config)

--- a/src/sys/filetracker.cpp
+++ b/src/sys/filetracker.cpp
@@ -1,0 +1,163 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2020 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#include <base/env_utils.hpp>
+#include <sys/filetracker.hpp>
+
+#include <windows.h>
+
+// Note: The FileTracker API has been created from msdn documentation.
+// It seems the documentation may be slightly incorrect with respect to return values in case of
+// error conditions, and possibly other topics.
+
+/* As of toolchain 19.27.29111, FileTracker DLL is detouring:
+CreateThread
+CreateFile{A|W}
+CopyFile{A|W|ExA|ExW}
+MoveFile{A|W|ExA|ExW}
+SetFileInformationByHandle
+ReplaceFileW - (if TRACKER_TRACK_REPLACEFILE env var exists)
+CreateHardLink{A|W}
+CreateProcess{A|W}
+CreateDirectory{A|W}
+RemoveDirectory{A|W}
+GetFileAttributes{A|W|ExA|ExW}
+DeleteFile{A|W}
+TerminateProcess
+ExitProcess
+DisableThreadLibraryCalls
+*/
+
+/// @brief Start a tracking context.
+/// @param intermediateDirectory The directory in which to store the tracking log.
+/// @param taskName Identifies the tracking context. This name is used to create the log file name.
+/// @returns An HRESULT with the SUCCEEDED bit set if the tracking context was created.
+HRESULT WINAPI StartTrackingContext(LPCTSTR intermediateDirectory, LPCTSTR taskName);
+
+/// @brief Starts a tracking context using a response file specifying a root marker.
+/// @param intermediateDirectory The directory in which to store the tracking log.
+/// @param taskName Identifies the tracking context. This name is used to create the log file name.
+/// @param rootMarkerResponseFile The pathname of a response file containing a root marker. The root
+/// name is used to group all tracking for a context together.
+/// @returns An HRESULT with the SUCCEEDED bit set if the tracking context was created.
+HRESULT WINAPI StartTrackingContextWithRoot(LPCTSTR intermediateDirectory,
+                                            LPCTSTR taskName,
+                                            LPCTSTR rootMarkerResponseFile);
+
+/// @brief End the current tracking context.
+/// @returns An HRESULT with the SUCCEEDED bit set if the tracking context was ended.
+HRESULT WINAPI EndTrackingContext();
+
+/// @brief Stops all tracking and frees any memory used by the tracking session.
+/// @returns Returns an HRESULT with the SUCCEEDED bit set if tracking was stopped.
+HRESULT WINAPI StopTrackingAndCleanup(void);
+
+/// @brief Suspends tracking in the current context.
+/// @returns An HRESULT with the SUCCEEDED bit set if tracking was suspended.
+HRESULT WINAPI SuspendTracking(void);
+
+/// @brief Resumes tracking in the current context.
+/// @returns An HRESULT with the SUCCEEDED bit set if tracking was resumed. E_FAIL is returned if
+/// tracking cannot be resumed because the context was not available.
+HRESULT WINAPI ResumeTracking();
+
+/// @brief Writes tracking logs for all threads and contexts.
+/// @param intermediateDirectory The directory in which to store the tracking log.
+/// @param tlogRootName The root name of the log file name.
+/// @note The msdn doc for return value is incorrect.
+HRESULT WINAPI WriteAllTLogs(LPCTSTR intermediateDirectory, LPCTSTR tlogRootName);
+
+/// @brief Writes logs files for the current context.
+/// @param intermediateDirectory The directory in which to store the tracking log.
+/// @param tlogRootName The root name of the log file name.
+/// @note The msdn doc for return value is incorrect.
+HRESULT WINAPI WriteContextTLogs(LPCTSTR intermediateDirectory, LPCTSTR tlogRootName);
+
+/// @brief Sets the global thread count, and assigns that count to the current thread.
+/// @param threadCount The number of threads to use.
+/// @returns An HRESULT with the SUCCEEDED bit set if the thread count was updated.
+HRESULT WINAPI SetThreadCount(int threadCount);
+
+namespace bcache {
+namespace filetracker {
+
+HMODULE handle;
+decltype(&::SuspendTracking) SuspendTracking;
+decltype(&::ResumeTracking) ResumeTracking;
+
+bool init() {
+  if (handle) {
+    return true;
+  }
+  env_var_t tracker_enabled("TRACKER_ENABLED");
+  if (!tracker_enabled.as_bool()) {
+    return false;
+  }
+  for (auto module_name : {"FileTracker64", "FileTracker32", "FileTracker"}) {
+    handle = GetModuleHandleA(module_name);
+    if (handle) {
+      break;
+    }
+  }
+  if (!handle) {
+    return false;
+  }
+#define FUNC_RESOLVE(x)                          \
+  do {                                           \
+    x = (decltype(x))GetProcAddress(handle, #x); \
+    if (!x) {                                    \
+      handle = nullptr;                          \
+      return false;                              \
+    }                                            \
+  } while (0)
+  FUNC_RESOLVE(SuspendTracking);
+  FUNC_RESOLVE(ResumeTracking);
+#undef FUNC_RESOLVE
+  return true;
+}
+
+void suspend() {
+  if (!init()) {
+    return;
+  }
+  SuspendTracking();
+}
+
+void resume() {
+  if (!init()) {
+    return;
+  }
+  ResumeTracking();
+}
+
+struct FileTrackerScopedSuppressor {
+  FileTrackerScopedSuppressor() {
+    suspend();
+  }
+  ~FileTrackerScopedSuppressor() {
+    resume();
+  }
+};
+
+// Ensure automatic suspend and resume of FileTracker for buildcache lifetime.
+// Unbalanced calls to suspend/resume is OK.
+static FileTrackerScopedSuppressor filetracker_singleton;
+
+}  // namespace filetracker
+}  // namespace bcache

--- a/src/sys/filetracker.hpp
+++ b/src/sys/filetracker.hpp
@@ -1,0 +1,37 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2018 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#ifndef BUILDCACHE_FILETRACKER_HPP_
+#define BUILDCACHE_FILETRACKER_HPP_
+
+namespace bcache {
+namespace filetracker {
+#ifdef _WIN32
+void suspend();
+void resume();
+#else
+inline void suspend() {
+}
+inline void resume() {
+}
+#endif
+}  // namespace filetracker
+}  // namespace bcache
+
+#endif  // BUILDCACHE_FILETRACKER_HPP_

--- a/src/wrappers/msvc_wrapper.cpp
+++ b/src/wrappers/msvc_wrapper.cpp
@@ -17,16 +17,17 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //--------------------------------------------------------------------------------------------------
 
-#include <wrappers/msvc_wrapper.hpp>
-
 #include <base/debug_utils.hpp>
 #include <base/env_utils.hpp>
 #include <base/unicode_utils.hpp>
 #include <config/configuration.hpp>
+#include <sys/filetracker.hpp>
 #include <sys/sys_utils.hpp>
+#include <wrappers/msvc_wrapper.hpp>
 
 #include <codecvt>
 #include <cstdlib>
+
 #include <fstream>
 #include <locale>
 #include <stdexcept>
@@ -282,7 +283,11 @@ std::map<std::string, expected_file_t> msvc_wrapper_t::get_build_files() {
 sys::run_result_t msvc_wrapper_t::run_for_miss() {
   // Capture printed source file name (stdout) in cache entry.
   scoped_unset_env_t scoped_off(ENV_VS_OUTPUT_REDIRECTION);
-  return program_wrapper_t::run_for_miss();
+  // Allow FileTracker for the duration of the compilation command.
+  filetracker::resume();
+  auto result = program_wrapper_t::run_for_miss();
+  filetracker::suspend();
+  return result;
 }
 
 }  // namespace bcache


### PR DESCRIPTION
When required (i.e. on Windows, using msvc wrapper, and `TRACKER_ENABLED` env var is set), only allow FileTracker to see file operations which occur during `run_for_miss`. 

This allows putting `BUILDCACHE_DIR` anywhere - it does not need to be on a hardcoded list of locations ignored by FileTracker.