### PR TITLE
msvc: fetch compiler version directly from executable

### DIFF
--- a/src/base/string_list.hpp
+++ b/src/base/string_list.hpp
@@ -39,6 +39,11 @@ public:
   string_list_t(std::initializer_list<std::string> list) : m_args(list) {
   }
 
+  /// @brief Construct a list from an const_iterator.
+  /// @param list The range to add to the string list object.
+  string_list_t(const_iterator first, const_iterator last) : m_args(first, last) {
+  }
+
   /// @brief Construct a list from command line arguments.
   /// @param argc Argument count.
   /// @param argv Argument array.

--- a/src/base/string_utils.hpp
+++ b/src/base/string_utils.hpp
@@ -1,0 +1,42 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2018 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#ifndef BUILDCACHE_STRING_UTILS_HPP_
+#define BUILDCACHE_STRING_UTILS_HPP_
+
+#include <string>
+#include <vector>
+
+namespace bcache {
+inline bool starts_with(const std::string& str, const std::string& sub_str) {
+  return str.substr(0, sub_str.size()) == sub_str;
+}
+
+inline std::vector<std::string> split(const std::string& str, char delimiter) {
+  std::vector<std::string> result;
+  for (std::string::size_type pos = 0, next = 0; next != std::string::npos;
+       pos = next + sizeof(delimiter)) {
+    next = str.find_first_of(delimiter, pos);
+    result.emplace_back(str.substr(pos, next - pos));
+  }
+  return result;
+}
+}  // namespace bcache
+
+#endif  // BUILDCACHE_STRING_UTILS_HPP_

--- a/src/wrappers/CMakeLists.txt
+++ b/src/wrappers/CMakeLists.txt
@@ -40,3 +40,6 @@ add_library(wrappers
   ti_c6x_wrapper.hpp
   )
 target_link_libraries(wrappers base config sys cache lua)
+if(MINGW)
+  target_link_libraries(wrappers version)
+endif()

--- a/src/wrappers/ti_common_wrapper.cpp
+++ b/src/wrappers/ti_common_wrapper.cpp
@@ -21,6 +21,7 @@
 
 #include <base/debug_utils.hpp>
 #include <base/file_utils.hpp>
+#include <base/string_utils.hpp>
 #include <base/unicode_utils.hpp>
 #include <config/configuration.hpp>
 
@@ -39,10 +40,6 @@
 
 namespace bcache {
 namespace {
-bool starts_with(const std::string& str, const std::string& sub_str) {
-  return str.substr(0, sub_str.size()) == sub_str;
-}
-
 bool has_debug_symbols(const string_list_t& args) {
   // The default behavior is to enable debugging.
   //   C6x default (sprui04b.pdf, 3.3.6):   --symdebug:dwarf


### PR DESCRIPTION
* removes need to execute `cl.exe` just for getting version
  * this is preferable for speed (i think, didn't bother testing), and also because the stderr output may sometimes be nondeterministic (what I ran into was `TRACKER_TRACE=1` dirtying the output).
* msvc `get_program_id` is now: `version.host_arch + version.target_arch + version.file_version`. This removes any artifacts of per-device paths and keeps only the important information.
  * in addition to `HASH_VERSION`, which IMO doesn't serve a purpose, but I left it there anyway.