### PR TITLE
windows: add mutex-based implementation of lock_file_t

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -29,6 +29,7 @@ The following options control the behavior of BuildCache:
 | `BUILDCACHE_DISABLE` | `disable` | Disable caching (bypass BuildCache) | false |
 | `BUILDCACHE_ACCURACY` | `accuracy` | Caching accuracy (see below) | DEFAULT |
 | `BUILDCACHE_READ_ONLY` | `read_only` | Only read and use the cache without updating it | false |
+| `BUILDCACHE_LOCAL_LOCKS` | `local_locks` | Use faster lockfile implementation, only safe if the cache is not on a fileshare | false |
 
 Note: Currently, only the TI C6x back end supports the `cache_link_commands`
 option.

--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -56,7 +56,7 @@ if(HAS_HMAC)
 endif()
 
 add_library(base ${BASE_SRC})
-target_link_libraries(base xxhash lz4 zstd)
+target_link_libraries(base xxhash lz4 zstd config)
 if(WIN32 OR MINGW)
   target_link_libraries(base userenv)
 elseif(OPENSSL_FOUND)

--- a/src/base/lock_file.cpp
+++ b/src/base/lock_file.cpp
@@ -17,13 +17,14 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //--------------------------------------------------------------------------------------------------
 
-#include <base/lock_file.hpp>
-
 #include <base/debug_utils.hpp>
 #include <base/file_utils.hpp>
+#include <base/lock_file.hpp>
 #include <base/unicode_utils.hpp>
+#include <config/configuration.hpp>
 
 #include <cstdint>
+
 #include <algorithm>
 
 #if defined(_WIN32)
@@ -43,6 +44,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
+
 #include <thread>
 #endif
 
@@ -78,7 +80,11 @@ bool file_is_too_old(const std::string& path) {
 
 lock_file_t::handle_t lock_file_t::invalid_handle() {
 #if defined(_WIN32)
-  return INVALID_HANDLE_VALUE;
+  if (config::local_locks()) {
+    return nullptr;
+  } else {
+    return INVALID_HANDLE_VALUE;
+  }
 #else
   return -1;
 #endif
@@ -86,45 +92,72 @@ lock_file_t::handle_t lock_file_t::invalid_handle() {
 
 lock_file_t::lock_file_t(const std::string& path) : m_path(path) {
 #if defined(_WIN32)
-  // Time values are in milliseconds.
-  const DWORD MAX_WAIT_TIME = 10000;  // We'll fail if the lock can't be acquired in 10s.
-  const DWORD MIN_SLEEP_TIME = 0;     // We start with 0, which is essentially just a yield.
-  const DWORD MAX_SLEEP_TIME = 50;
+  if (config::local_locks()) {
+    // Time values are in milliseconds.
+    const DWORD MAX_WAIT_TIME = 10000;  // We'll fail if the lock can't be acquired in 10s.
 
-  DWORD total_wait_time = 0;
-  DWORD sleep_time = MIN_SLEEP_TIME;
-
-  while (total_wait_time < MAX_WAIT_TIME) {
-    // Try to create the lock file in exclusive mode.
-    m_handle = CreateFileW(utf8_to_ucs2(path).c_str(),
-                           GENERIC_READ | GENERIC_WRITE,
-                           0,  // No sharing => exclusive access.
-                           nullptr,
-                           CREATE_ALWAYS,
-                           FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE,
-                           nullptr);
-    if (m_handle != INVALID_HANDLE_VALUE) {
-      // We got the lock!
-      break;
-    } else {
-      // We were unable to create the file. We allow the following errors by waiting and trying
-      // again later: ERROR_SHARING_VIOLATION (the lock is already held by another process) and
-      // ERROR_ACCESS_DENIED (this can can in fact be due to a pending delete, see
-      // https://stackoverflow.com/q/6680491/5778708). Any other errors are treated as unrecoverable
-      // and result in an unlocked lock_file_t object.
-      const auto last_error = GetLastError();
-      if (last_error != ERROR_SHARING_VIOLATION && last_error != ERROR_ACCESS_DENIED) {
-        debug::log(debug::ERROR) << "Failed to open the lock file " << path
-                                 << " (error code: " << last_error << ")";
-        break;
-      }
+    // Just convert the path into a mutex name.
+    auto path_w = utf8_to_ucs2(path);
+    // Object names may not contain backslashes.
+    std::replace(path_w.begin(), path_w.end(), L'\\', L'_');
+    // Place in the Global namespace, so the mutex will work for any instance of buildcache on the
+    // local machine.
+    const auto name = L"Global\\" + path_w;
+    // Get a handle to a named mutex. The object may be created now for our call, or previously for
+    // another instance of buildcache - it doesn't make a difference.
+    m_handle = CreateMutexW(nullptr, FALSE, name.c_str());
+    if (m_handle == invalid_handle()) {
+      return;
     }
+    const DWORD status = WaitForSingleObject(m_handle, MAX_WAIT_TIME);
+    // WAIT_OBJECT_0 and WAIT_ABANDONED both indicate the lock has been acquired. WAIT_ABANDONED
+    // additionally indicates that the previous thread owning the lock terminated without properly
+    // releasing it.
+    if (!(status == WAIT_OBJECT_0 || status == WAIT_ABANDONED)) {
+      CloseHandle(m_handle);
+      m_handle = invalid_handle();
+    }
+  } else {
+    // Time values are in milliseconds.
+    const DWORD MAX_WAIT_TIME = 10000;  // We'll fail if the lock can't be acquired in 10s.
+    const DWORD MIN_SLEEP_TIME = 0;     // We start with 0, which is essentially just a yield.
+    const DWORD MAX_SLEEP_TIME = 50;
 
-    // Wait for a small period of time to give other processes a chance to release the lock.
-    // Note: Handle both short and long blocks by increasing the sleep time for every new try.
-    Sleep(sleep_time);
-    total_wait_time += sleep_time;
-    sleep_time = std::min(sleep_time * 2 + 1, MAX_SLEEP_TIME);
+    DWORD total_wait_time = 0;
+    DWORD sleep_time = MIN_SLEEP_TIME;
+
+    while (total_wait_time < MAX_WAIT_TIME) {
+      // Try to create the lock file in exclusive mode.
+      m_handle = CreateFileW(utf8_to_ucs2(path).c_str(),
+                             GENERIC_READ | GENERIC_WRITE,
+                             0,  // No sharing => exclusive access.
+                             nullptr,
+                             CREATE_ALWAYS,
+                             FILE_ATTRIBUTE_NORMAL | FILE_FLAG_DELETE_ON_CLOSE,
+                             nullptr);
+      if (m_handle != INVALID_HANDLE_VALUE) {
+        // We got the lock!
+        break;
+      } else {
+        // We were unable to create the file. We allow the following errors by waiting and trying
+        // again later: ERROR_SHARING_VIOLATION (the lock is already held by another process) and
+        // ERROR_ACCESS_DENIED (this can can in fact be due to a pending delete, see
+        // https://stackoverflow.com/q/6680491/5778708). Any other errors are treated as
+        // unrecoverable and result in an unlocked lock_file_t object.
+        const auto last_error = GetLastError();
+        if (last_error != ERROR_SHARING_VIOLATION && last_error != ERROR_ACCESS_DENIED) {
+          debug::log(debug::ERROR)
+              << "Failed to open the lock file " << path << " (error code: " << last_error << ")";
+          break;
+        }
+      }
+
+      // Wait for a small period of time to give other processes a chance to release the lock.
+      // Note: Handle both short and long blocks by increasing the sleep time for every new try.
+      Sleep(sleep_time);
+      total_wait_time += sleep_time;
+      sleep_time = std::min(sleep_time * 2 + 1, MAX_SLEEP_TIME);
+    }
   }
 #else
   // Time values are in microseconds.
@@ -263,9 +296,18 @@ lock_file_t& lock_file_t::operator=(lock_file_t&& other) noexcept {
 
 lock_file_t::~lock_file_t() {
 #if defined(_WIN32)
-  if (m_handle != INVALID_HANDLE_VALUE) {
-    // Close the lock file. This also deletes the file due to FILE_FLAG_DELETE_ON_CLOSE.
-    CloseHandle(m_handle);
+  if (config::local_locks()) {
+    if (m_handle) {
+      if (m_has_lock) {
+        ReleaseMutex(m_handle);
+      }
+      CloseHandle(m_handle);
+    }
+  } else {
+    if (m_handle != INVALID_HANDLE_VALUE) {
+      // Close the lock file. This also deletes the file due to FILE_FLAG_DELETE_ON_CLOSE.
+      CloseHandle(m_handle);
+    }
   }
 #else
   if (m_handle >= 0) {

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -57,6 +57,7 @@ int32_t s_compress_level = -1;
 bool s_perf = false;
 bool s_disable = false;
 bool s_read_only = false;
+bool s_local_locks = false;
 config::cache_accuracy_t s_accuracy = config::cache_accuracy_t::DEFAULT;
 config::compress_format_t s_compress_format = config::compress_format_t::DEFAULT;
 
@@ -290,6 +291,14 @@ void load_from_file(const std::string& file_name) {
     }
   }
 
+  // Get "local_locks".
+  {
+    const auto* node = cJSON_GetObjectItemCaseSensitive(root, "local_locks");
+    if (cJSON_IsBool(node)) {
+      s_local_locks = cJSON_IsTrue(node);
+    }
+  }
+
   cJSON_Delete(root);
 }
 }  // namespace
@@ -513,6 +522,14 @@ void init() {
         s_read_only = read_only_env.as_bool();
       }
     }
+
+    // Get the local lock flag from the environment.
+    {
+      const env_var_t local_locks_env("BUILDCACHE_LOCAL_LOCKS");
+      if (local_locks_env) {
+        s_local_locks = local_locks_env.as_bool();
+      }
+    }
   } catch (...) {
     // If we could not initialize the configuration, we can't proceed. We need to disable the cache.
     s_disable = true;
@@ -602,6 +619,10 @@ compress_format_t compress_format() {
 
 bool read_only() {
   return s_read_only;
+}
+
+bool local_locks() {
+  return s_local_locks;
 }
 
 }  // namespace config

--- a/src/config/configuration.hpp
+++ b/src/config/configuration.hpp
@@ -117,6 +117,9 @@ bool disable();
 /// @returns true if the readonly mode is enabled.
 bool read_only();
 
+/// @returns true if lock_file_t may use implementation optimized for sharing on local machine only.
+bool local_locks();
+
 /// @returns the cache accuracy.
 cache_accuracy_t accuracy();
 


### PR DESCRIPTION
Add an off-by-default option to switch implementation of `lock_file_t` to something based on win32 mutexes instead of using the filesystem.