### PR TITLE
Cache the result of get_program_id()

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -34,6 +34,8 @@ set(BASE_SRC
   serializer_utils.hpp
   string_list.hpp
   string_list.cpp
+  time_utils.cpp
+  time_utils.hpp
   unicode_utils.cpp
   unicode_utils.hpp
   )

--- a/src/base/file_utils.hpp
+++ b/src/base/file_utils.hpp
@@ -24,6 +24,8 @@
 #include <string>
 #include <vector>
 
+#include <base/time_utils.hpp>
+
 namespace bcache {
 namespace file {
 /// @brief A helper class for handling temporary files and directories.
@@ -51,12 +53,9 @@ private:
 /// @brief Information about a file.
 class file_info_t {
 public:
-  /// @brief File time (seconds since the Unix epoch, i.e. 00:00:00 UTC on 1 January 1970).
-  using time_t = int64_t;
-
   file_info_t(const std::string& path,
-              const time_t modify_time,
-              const time_t access_time,
+              const time::seconds_t modify_time,
+              const time::seconds_t access_time,
               const int64_t size,
               const bool is_dir);
 
@@ -67,13 +66,13 @@ public:
 
   /// @returns the last modification time of the file, or the most recent modification time for any
   /// of the recursively contained files if this is a directory.
-  time_t modify_time() const {
+  time::seconds_t modify_time() const {
     return m_modify_time;
   }
 
   /// @returns the last access time of the file, or the most recent access time for any of the
   /// recursively contained files if this is a directory.
-  time_t access_time() const {
+  time::seconds_t access_time() const {
     return m_access_time;
   }
 
@@ -90,8 +89,8 @@ public:
 
 private:
   std::string m_path;
-  time_t m_modify_time;
-  time_t m_access_time;
+  time::seconds_t m_modify_time;
+  time::seconds_t m_access_time;
   int64_t m_size;
   bool m_is_dir;
 };

--- a/src/base/time_utils.cpp
+++ b/src/base/time_utils.cpp
@@ -1,0 +1,70 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2020 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#include <base/time_utils.hpp>
+
+#if defined(_WIN32)
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#undef ERROR
+#undef log
+#else
+#include <sys/time.h>
+#include <sys/types.h>
+#endif
+
+#include <stdexcept>
+
+namespace bcache {
+namespace time {
+
+seconds_t seconds_since_epoch() {
+#if defined(_WIN32)
+  FILETIME file_time;
+  GetSystemTimeAsFileTime(&file_time);
+  return win32_filetime_to_unix_epoch(file_time.dwLowDateTime, file_time.dwHighDateTime);
+#else
+  struct timeval now;
+  if (::gettimeofday(&now, nullptr) == 0) {
+    return static_cast<time::seconds_t>(now.tv_sec);
+  } else {
+    throw std::runtime_error("Could not get system time.");
+  }
+#endif
+}
+
+#if defined(_WIN32)
+seconds_t win32_filetime_to_unix_epoch(const uint32_t low, const uint32_t high) {
+  // Convert the FILETIME struct to a 64-bit integer.
+  const auto t64 = static_cast<int64_t>(static_cast<uint64_t>(static_cast<uint32_t>(low)) |
+                                        (static_cast<uint64_t>(static_cast<uint32_t>(high)) << 32));
+
+  // The FILETIME represents the number of 100-nanosecond intervals since January 1, 1601 (UTC).
+  // I.e. the Windows epoch starts 11644473600 seconds before the UNIX epoch.
+  return static_cast<time::seconds_t>((t64 / 10000000L) - 11644473600L);
+}
+#endif
+
+}  // namespace time
+}  // namespace bcache

--- a/src/base/time_utils.hpp
+++ b/src/base/time_utils.hpp
@@ -1,0 +1,50 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2020 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#ifndef BUILDCACHE_TIME_UTILS_HPP_
+#define BUILDCACHE_TIME_UTILS_HPP_
+
+#include <cstdint>
+
+namespace bcache {
+namespace time {
+/// @brief Time in seconds since the Unix epoch.
+///
+/// Integer number of seconds since the Unix epoch, i.e. 00:00:00 UTC on 1 January 1970. The value
+/// is represented with 64 bits (so we're good wrt the 2038 problem).
+using seconds_t = int64_t;
+
+/// @brief Get the current time in seconds.
+///
+/// Time values returned by this function are compatible with file system time values.
+/// @returns the number of seconds since the Unix epoch.
+seconds_t seconds_since_epoch();
+
+#if defined(_WIN32)
+/// @brief Convert a Win32 FILETIME to the Unix epoch.
+/// @param low The 32 lower bits of the FILETIME (dwLowDateTime).
+/// @param high The 32 upper bits of the FILETIME (dwHighDateTime).
+/// @returns the time in seconds since the Unix epoch.
+seconds_t win32_filetime_to_unix_epoch(const uint32_t low, const uint32_t high);
+#endif
+
+}  // namespace time
+}  // namespace bcache
+
+#endif  // BUILDCACHE_TIME_UTILS_HPP_

--- a/src/cache/CMakeLists.txt
+++ b/src/cache/CMakeLists.txt
@@ -25,6 +25,8 @@ set(CACHE_SRCS
   cache_entry.hpp
   cache_stats.cpp
   cache_stats.hpp
+  data_store.cpp
+  data_store.hpp
   local_cache.cpp
   local_cache.hpp
   redis_cache_provider.cpp

--- a/src/cache/data_store.cpp
+++ b/src/cache/data_store.cpp
@@ -1,0 +1,162 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2020 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#include <cache/data_store.hpp>
+
+#include <base/debug_utils.hpp>
+#include <base/file_utils.hpp>
+#include <config/configuration.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <stdexcept>
+
+namespace bcache {
+
+namespace {
+bool is_time_for_housekeeping() {
+  // Get the time since the epoch, in microseconds.
+  const auto t =
+      std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now())
+          .time_since_epoch()
+          .count();
+
+  // Scramble the timestamp (to make up for possible problems with timer accuracy).
+  const auto rnd = (t ^ (t >> 7)) ^ ((t >> 14) ^ (t >> 20));
+
+  // Only perform housekeeping 0.1% of the times that we are called.
+  // Note: We should not need to do this very often, since meta data should be small, and most of
+  // the items should be self-purging (whenever an expired item is requested it is removed).
+  return (rnd % 1000L) == 0L;
+}
+
+std::string encode_file_time(const time::seconds_t t) {
+  std::string str(8, 0);
+  str[0] = static_cast<char>(static_cast<uint8_t>(t));
+  str[1] = static_cast<char>(static_cast<uint8_t>(t >> 8));
+  str[2] = static_cast<char>(static_cast<uint8_t>(t >> 16));
+  str[3] = static_cast<char>(static_cast<uint8_t>(t >> 24));
+  str[4] = static_cast<char>(static_cast<uint8_t>(t >> 32));
+  str[5] = static_cast<char>(static_cast<uint8_t>(t >> 40));
+  str[6] = static_cast<char>(static_cast<uint8_t>(t >> 48));
+  str[7] = static_cast<char>(static_cast<uint8_t>(t >> 56));
+  return str;
+}
+
+time::seconds_t decode_file_time(const std::string& str) {
+  return static_cast<time::seconds_t>(static_cast<uint8_t>(str[0])) |
+         (static_cast<time::seconds_t>(static_cast<uint8_t>(str[1])) << 8) |
+         (static_cast<time::seconds_t>(static_cast<uint8_t>(str[2])) << 16) |
+         (static_cast<time::seconds_t>(static_cast<uint8_t>(str[3])) << 24) |
+         (static_cast<time::seconds_t>(static_cast<uint8_t>(str[4])) << 32) |
+         (static_cast<time::seconds_t>(static_cast<uint8_t>(str[5])) << 40) |
+         (static_cast<time::seconds_t>(static_cast<uint8_t>(str[6])) << 48) |
+         (static_cast<time::seconds_t>(static_cast<uint8_t>(str[7])) << 56);
+}
+
+}  // namespace
+
+data_store_t::data_store_t(const std::string& name) {
+  // Define the data store root directory.
+  m_root_dir = file::append_path(config::dir(), name);
+
+  // Occassionally perform housekeeping.
+  if (is_time_for_housekeeping()) {
+    perform_housekeeping();
+  }
+}
+
+void data_store_t::store_item(const std::string& key,
+                              const std::string& value,
+                              const time::seconds_t timeout) {
+  try {
+    // Make sure that we have a local data folder to work in.
+    file::create_dir_with_parents(m_root_dir);
+
+    const auto file_path = make_file_path(key);
+    const auto raw_data = encode_file_time(time::seconds_since_epoch() + timeout) + value;
+
+    // Save to a temporary file first and once the write operation has succeeded rename it to the
+    // target file.
+    auto tmp_file = file::tmp_file_t(file::get_dir_part(file_path), ".tmp");
+    file::write(raw_data, tmp_file.path());
+
+    // Move the temporary file to its target name.
+    file::move(tmp_file.path(), file_path);
+  } catch (...) {
+    // We just silence errors, since data items are volatile anyway.
+  }
+}
+
+data_store_t::item_t data_store_t::get_item(const std::string& key) {
+  try {
+    // Read and decode the data item.
+    const auto raw_data = file::read(make_file_path(key));
+    if (raw_data.size() < 8) {
+      return item_t();
+    }
+    const auto expires = decode_file_time(raw_data);
+    if (expires < time::seconds_since_epoch()) {
+      remove_item(key);
+      return item_t();
+    }
+    return item_t(raw_data.substr(8));
+  } catch (std::runtime_error&) {
+    return item_t();
+  }
+}
+
+void data_store_t::remove_item(const std::string& key) {
+  file::remove_file(make_file_path(key), true);
+}
+
+void data_store_t::clear() {
+  // Remove all data store items.
+  if (file::dir_exists(m_root_dir)) {
+    const auto files = file::walk_directory(m_root_dir);
+    for (const auto& file : files) {
+      if (!file.is_dir()) {
+        file::remove_file(file.path());
+      }
+    }
+  }
+}
+
+std::string data_store_t::make_file_path(const std::string& key) {
+  return file::append_path(m_root_dir, key);
+}
+
+void data_store_t::perform_housekeeping() {
+  debug::log(debug::INFO) << "Performing housekeeping for data store \""
+                          << file::get_file_part(m_root_dir) << "\"...";
+
+  // Iterate over all data store items with get_item(), which will remove the items that have
+  // expired.
+  if (file::dir_exists(m_root_dir)) {
+    const auto files = file::walk_directory(m_root_dir);
+    for (const auto& file : files) {
+      if (!file.is_dir()) {
+        const auto key = file::get_file_part(file.path());
+        (void)get_item(key);
+      }
+    }
+  }
+}
+
+}  // namespace bcache

--- a/src/cache/data_store.hpp
+++ b/src/cache/data_store.hpp
@@ -1,0 +1,97 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2020 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#ifndef BUILDCACHE_DATA_STORE_HPP_
+#define BUILDCACHE_DATA_STORE_HPP_
+
+#include <base/time_utils.hpp>
+
+#include <string>
+
+namespace bcache {
+/// @brief Provide access to a local key/value store.
+///
+/// The key/value store provides a convenient way to store data that is to be shared between
+/// multiple BuildCache instances on a local machine.
+///
+/// The values are not stored indefinitely. For instance, the store may be cleared between system
+/// sessions, and values that are stored in the data store may have an expiry time after which
+/// they are considered invalid.
+class data_store_t {
+public:
+  /// @brief A data item.
+  class item_t {
+  public:
+    /// @brief Construct a valid data item.
+    /// @param value The data string.
+    item_t(const std::string& value) : m_value(value), m_is_valid(true) {
+    }
+
+    /// @brief Construct an invalid (empty) data item.
+    item_t() {
+    }
+
+    /// @returns the data string.
+    const std::string& value() const {
+      return m_value;
+    }
+
+    /// @brief Check if the item is valid.
+    /// @returns true if the item is valid, else false.
+    bool is_valid() const {
+      return m_is_valid;
+    }
+
+  private:
+    const std::string m_value;
+    const bool m_is_valid = false;
+  };
+
+  /// @brief Construct a data store.
+  /// @param name Name of the data store.
+  data_store_t(const std::string& name);
+
+  /// @brief Add or overwrite a data item.
+  /// @param key The ID of the item to store.
+  /// @param value The data to store.
+  /// @param timeout The life time of the item.
+  void store_item(const std::string& key, const std::string& value, const time::seconds_t timeout);
+
+  /// @brief Get a data item.
+  /// @param key The key of the item to retrieve.
+  /// @returns a valid item if one could be found, or an invalid (empty) item if the requested item
+  /// could not be found, or if the item expiry time has past.
+  item_t get_item(const std::string& key);
+
+  /// @brief Remove a data item.
+  /// @param key The ID of the item to retrieve.
+  void remove_item(const std::string& key);
+
+  /// @brief Clear the data store.
+  void clear();
+
+private:
+  std::string make_file_path(const std::string& key);
+  void perform_housekeeping();
+
+  std::string m_root_dir;
+};
+}  // namespace bcache
+
+#endif  // BUILDCACHE_DATA_STORE_HPP_

--- a/src/cache/s3_cache_provider.cpp
+++ b/src/cache/s3_cache_provider.cpp
@@ -57,22 +57,22 @@ std::string get_date_rfc2616_gmt() {
   // manner?
 
   // Set the locale to "C" (and save old locale).
-  const auto* old_locale_ptr = setlocale(LC_ALL, nullptr);
-  const auto old_locale = old_locale_ptr ? std::string(setlocale(LC_ALL, nullptr)) : std::string();
-  setlocale(LC_ALL, "C");
+  const auto* old_locale_ptr = ::setlocale(LC_ALL, nullptr);
+  const auto old_locale = old_locale_ptr ? std::string(::setlocale(LC_ALL, nullptr)) : std::string();
+  ::setlocale(LC_ALL, "C");
 
   // Get the current date & time.
-  time_t now = time(0);
-  struct tm tm = *gmtime(&now);
+  time_t now = ::time(0);
+  struct tm tm = *::gmtime(&now);
 
   // Format the date & time according to RFC2616.
   char buf[100];
-  if (strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", &tm) == 0) {
+  if (::strftime(buf, sizeof(buf), "%a, %d %b %Y %H:%M:%S GMT", &tm) == 0) {
     throw std::runtime_error("strftime failed");
   }
 
   // Restore the old locale.
-  setlocale(LC_ALL, old_locale.c_str());
+  ::setlocale(LC_ALL, old_locale.c_str());
 
   return std::string(&buf[0]);
 }

--- a/src/wrappers/program_wrapper.hpp
+++ b/src/wrappers/program_wrapper.hpp
@@ -120,6 +120,8 @@ protected:
   const string_list_t& m_args;
 
 private:
+  std::string get_program_id_cached();
+
   cache_t m_cache;
 };
 }  // namespace bcache


### PR DESCRIPTION
This reduces the get_program_id() query to a single `stat()` call plus a single file-read operation. On a Linux machine this means:

| Program | Lookup miss | Lookup hit |
|---|---|---|
| gcc | 1 ms | 0.04 ms |
| clang | 13 ms | 0.04 ms |
