### PR TITLE
Add a BUILDCACHE_READ_ONLY_REMOTE setting

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -27,6 +27,7 @@ The following options control the behavior of BuildCache:
 | `BUILDCACHE_PERF` | `perf` | Enable performance logging | false |
 | `BUILDCACHE_PREFIX` | `prefix` | Prefix command for cache misses | None |
 | `BUILDCACHE_READ_ONLY` | `read_only` | Only read and use the cache without updating it | false |
+| `BUILDCACHE_READ_ONLY_REMOTE` | `read_only_remote` | Only read and use the remote cache without updating it (implied by `BUILDCACHE_READ_ONLY`) | false |
 | `BUILDCACHE_REMOTE` | `remote` | Address of remote cache server (`protocol://host:port/path`, where `protocol` can be `redis` or `s3`, and `port` and `path` are optional) | None |
 | `BUILDCACHE_REMOTE_LOCKS` | `remote_locks` | Use a (potentially slower) file locking mechanism that is safe if the local cache is on a fileshare | false |
 | `BUILDCACHE_S3_ACCESS` | `s3_access` | S3 access key | None |

--- a/src/cache/cache.cpp
+++ b/src/cache/cache.cpp
@@ -99,7 +99,7 @@ void cache_t::add(const hasher_t::hash_t hash,
   }
 
   // Add the entry to the remote cache.
-  if (m_remote_cache.is_connected()) {
+  if (m_remote_cache.is_connected() && !config::read_only_remote()) {
     const auto max_remote_size = config::max_remote_entry_size();
     if (size < max_remote_size || max_remote_size <= 0) {
       // Note: We always compress entries for the remote cache.

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -67,6 +67,7 @@ int64_t s_max_remote_entry_size = DEFAULT_MAX_REMOTE_ENTRY_SIZE;
 bool s_perf = false;
 std::string s_prefix;
 bool s_read_only = false;
+bool s_read_only_remote = false;
 bool s_remote_locks = false;
 std::string s_remote;
 std::string s_s3_access;
@@ -266,6 +267,13 @@ void load_from_file(const std::string& file_name) {
     const auto* node = cJSON_GetObjectItemCaseSensitive(root, "read_only");
     if (cJSON_IsBool(node)) {
       s_read_only = cJSON_IsTrue(node);
+    }
+  }
+
+  {
+    const auto* node = cJSON_GetObjectItemCaseSensitive(root, "read_only_remote");
+    if (cJSON_IsBool(node)) {
+      s_read_only_remote = cJSON_IsTrue(node);
     }
   }
 
@@ -486,6 +494,13 @@ void init() {
     }
 
     {
+      const env_var_t env("BUILDCACHE_READ_ONLY_REMOTE");
+      if (env) {
+        s_read_only_remote = env.as_bool();
+      }
+    }
+
+    {
       const env_var_t env("BUILDCACHE_REMOTE");
       if (env) {
         s_remote = env.as_string();
@@ -597,6 +612,10 @@ const std::string& prefix() {
 
 bool read_only() {
   return s_read_only;
+}
+
+bool read_only_remote() {
+  return s_read_only_remote;
 }
 
 const std::string& remote() {

--- a/src/config/configuration.hpp
+++ b/src/config/configuration.hpp
@@ -114,6 +114,9 @@ const std::string& prefix();
 /// @returns true if the readonly mode is enabled.
 bool read_only();
 
+/// @returns true if the remote cache is read only.
+bool read_only_remote();
+
 /// @returns the remote cache service address.
 const std::string& remote();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,6 +199,8 @@ std::unique_ptr<bcache::program_wrapper_t> find_suitable_wrapper(
     std::cout << "  BUILDCACHE_PREFIX:                 " << bcache::config::prefix() << "\n";
     std::cout << "  BUILDCACHE_READ_ONLY:              "
               << (bcache::config::read_only() ? "true" : "false") << "\n";
+    std::cout << "  BUILDCACHE_READ_ONLY_REMOTE:       "
+              << (bcache::config::read_only_remote() ? "true" : "false") << "\n";
     std::cout << "  BUILDCACHE_REMOTE:                 " << bcache::config::remote() << "\n";
     std::cout << "  BUILDCACHE_REMOTE_LOCKS:           "
               << (bcache::config::remote_locks() ? "true" : "false") << "\n";


### PR DESCRIPTION
The remote cache is read but not updated if this setting is true.

This closes #107 