### PR TITLE
Add a GitHub Action for clang-format

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,24 @@
+name: clang-format
+
+on: [push]
+
+jobs:
+  clang-format-job:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install clang-format 6.0
+      run: |
+        sudo apt install clang-format-6.0
+        clang-format-6.0 --version
+    - uses: actions/checkout@v2
+    - name: Check format
+      run: |
+        cd src
+        find -name *.h -o -name *.cpp -o -name *.inl | xargs clang-format-6.0 -i
+        git diff
+    - uses: peter-evans/create-pull-request@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: 'Fixes by clang-format'
+        title: 'Fixes by clang-format'
+        branch: clang-format-patches


### PR DESCRIPTION
Add an action that will be executed on every push. Will create a PR if formatting changes are detected. Running on ubuntu-latest and using clang-format-6.0

Closes https://github.com/mbitsnbites/buildcache/issues/100

Here is an example on a PR based on running this action
https://github.com/magnesj/buildcache/pull/5