### PR TITLE
feat: add option to hash additional files

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -18,6 +18,7 @@ The following options control the behavior of BuildCache:
 | `BUILDCACHE_DIR` | - | The cache root directory | `$HOME/.buildcache` |
 | `BUILDCACHE_DISABLE` | `disable` | Disable caching (bypass BuildCache) | false |
 | `BUILDCACHE_HARD_LINKS` | `hard_links` | Allow the use of hard links when caching | false |
+| `BUILDCACHE_HASH_EXTRA_FILES` | `hash_extra_files` | Extra file(s) whose content to add to the hash | None |
 | `BUILDCACHE_IMPERSONATE` | `impersonate` | Explicitly set the executable to wrap | None |
 | `BUILDCACHE_LOG_FILE` | `log_file` | Log file path (empty for stdout) | None |
 | `BUILDCACHE_LUA_PATH` | `lua_paths` | Extra path(s) to Lua wrappers | None |
@@ -154,3 +155,25 @@ level for the compressor.
 
 Note: The "compress" setting must be set to true in order to utilize this
 setting.
+
+## BUILDCACHE_HASH_EXTRA_FILES
+
+When calculating the hash of a translation unit, buildcache tries to take all
+factors affecting the output into account. This includes things like the command line
+or the preprocessed source. But sometimes there are additional factors
+buildcache does not know about.
+
+For example the Clang compiler has an option to read an exclusion list for
+the sanitizers (`-fsanitize-blacklist`). This file affects the compilation
+output but buildcache is not aware of that. By passing the file
+name in the `BUILDCACHE_HASH_EXTRA_FILES` configuration option, its content
+will be added to the translation unit hash and taken into account when
+doing a cache lookup.
+
+Another use case is the versioning of the cache content. Using the above example,
+you may have tainted your cache as you forgot about the sanitizer
+exclusion list in your first run. One solution would now be to drop the whole cache.
+But in case of a shared remote cache, this might affect other caching tools and you
+might not even be able to zap the remote cache. Creating a text file with a simple
+versioning number and adding that to the `BUILDCACHE_HASH_EXTRA_FILES` will then
+effectively abandon the previous cache output.

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -58,6 +58,7 @@ int32_t s_debug = -1;
 bool s_disable = false;
 std::string s_dir;
 bool s_hard_links = false;
+string_list_t s_hash_extra_files;
 std::string s_impersonate;
 std::string s_log_file;
 string_list_t s_lua_paths;
@@ -203,6 +204,15 @@ void load_from_file(const std::string& file_name) {
     const auto* node = cJSON_GetObjectItemCaseSensitive(root, "hard_links");
     if (cJSON_IsBool(node)) {
       s_hard_links = cJSON_IsTrue(node);
+    }
+  }
+
+  {
+    const auto* node = cJSON_GetObjectItemCaseSensitive(root, "hash_extra_files");
+    cJSON* child_node;
+    cJSON_ArrayForEach(child_node, node) {
+      const auto str = std::string(child_node->valuestring);
+      s_hash_extra_files += str;
     }
   }
 
@@ -427,6 +437,13 @@ void init() {
     }
 
     {
+      const env_var_t env("BUILDCACHE_HASH_EXTRA_FILES");
+      if (env) {
+        s_hash_extra_files = string_list_t(env.as_string(), PATH_DELIMITER) + s_hash_extra_files;
+      }
+    }
+
+    {
       const env_var_t env("BUILDCACHE_IMPERSONATE");
       if (env) {
         s_impersonate = env.as_string();
@@ -591,6 +608,10 @@ bool disable() {
 
 bool hard_links() {
   return s_hard_links;
+}
+
+string_list_t hash_extra_files() {
+  return s_hash_extra_files;
 }
 
 const std::string& impersonate() {

--- a/src/config/configuration.hpp
+++ b/src/config/configuration.hpp
@@ -87,6 +87,9 @@ bool disable();
 /// @returns true if BuildCache should use hard links when possible.
 bool hard_links();
 
+/// @returns a list of extra files to hash.
+string_list_t hash_extra_files();
+
 /// @returns the executable to impersonate.
 const std::string& impersonate();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,6 +182,8 @@ std::unique_ptr<bcache::program_wrapper_t> find_suitable_wrapper(
               << (bcache::config::disable() ? "true" : "false") << "\n";
     std::cout << "  BUILDCACHE_HARD_LINKS:             "
               << (bcache::config::hard_links() ? "true" : "false") << "\n";
+    std::cout << "  BUILDCACHE_HASH_EXTRA_FILES:       "
+              << bcache::config::hash_extra_files().join(PATH_DELIMITER, false) << "\n";
     std::cout << "  BUILDCACHE_IMPERSONATE:            " << bcache::config::impersonate() << "\n";
     std::cout << "  BUILDCACHE_LOG_FILE:               " << bcache::config::log_file() << "\n";
     std::cout << "  BUILDCACHE_LUA_PATH:               "

--- a/src/sys/perf_utils.cpp
+++ b/src/sys/perf_utils.cpp
@@ -88,6 +88,7 @@ void report() {
     std::cerr << "Preprocess:            " << perf_us_t(ID_PREPROCESS) << "\n";
     std::cerr << "Filter arguments:      " << perf_us_t(ID_FILTER_ARGS) << "\n";
     std::cerr << "Get program id:        " << perf_us_t(ID_GET_PRG_ID) << "\n";
+    std::cerr << "Hash extra files:      " << perf_us_t(ID_HASH_EXTRA_FILES) << "\n";
     std::cerr << "Cache lookup:          " << perf_us_t(ID_CACHE_LOOKUP) << "\n";
     std::cerr << "Retreive cached files: " << perf_us_t(ID_RETRIEVE_CACHED_FILES) << "\n";
     std::cerr << "Get build files:       " << perf_us_t(ID_GET_BUILD_FILES) << "\n";

--- a/src/sys/perf_utils.hpp
+++ b/src/sys/perf_utils.hpp
@@ -44,6 +44,7 @@ enum id_t {
   ID_RUN_FOR_FALLBACK = 15,
   ID_UPDATE_STATS = 16,
   ID_TOTAL = 17,
+  ID_HASH_EXTRA_FILES = 18,
   NUM_PERF_IDS
 };
 

--- a/src/wrappers/program_wrapper.cpp
+++ b/src/wrappers/program_wrapper.cpp
@@ -91,6 +91,13 @@ bool program_wrapper_t::handle_command(int& return_code) {
     // Start a hash.
     hasher_t hasher;
 
+    // Add additional file contents to the resulting hash.
+    PERF_START(HASH_EXTRA_FILES);
+    for (const auto& extra_file : bcache::config::hash_extra_files()) {
+      hasher.update_from_file(extra_file);
+    }
+    PERF_STOP(HASH_EXTRA_FILES);
+
     // Hash the preprocessed file contents.
     PERF_START(PREPROCESS);
     hasher.update(preprocess_source());


### PR DESCRIPTION
Add an option to read and hash the content of extra files
like ccache also provides in the `CCACHE_EXTRAFILES`.

This functionality could come in handy until buildcache gets
an understanding for the -fsanitize-blacklist Clang compiler
option.