### PR TITLE
feat: Add HTTP cache provider

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -29,7 +29,7 @@ The following options control the behavior of BuildCache:
 | `BUILDCACHE_PREFIX` | `prefix` | Prefix command for cache misses | None |
 | `BUILDCACHE_READ_ONLY` | `read_only` | Only read and use the cache without updating it | false |
 | `BUILDCACHE_READ_ONLY_REMOTE` | `read_only_remote` | Only read and use the remote cache without updating it (implied by `BUILDCACHE_READ_ONLY`) | false |
-| `BUILDCACHE_REMOTE` | `remote` | Address of remote cache server (`protocol://host:port/path`, where `protocol` can be `redis` or `s3`, and `port` and `path` are optional) | None |
+| `BUILDCACHE_REMOTE` | `remote` | Address of remote cache server (`protocol://host:port/path`, where `protocol` can be `http`, `redis` or `s3`, and `port` and `path` are optional) | None |
 | `BUILDCACHE_REMOTE_LOCKS` | `remote_locks` | Use a (potentially slower) file locking mechanism that is safe if the local cache is on a fileshare | false |
 | `BUILDCACHE_S3_ACCESS` | `s3_access` | S3 access key | None |
 | `BUILDCACHE_S3_SECRET` | `s3_secret` | S3 secret key | None |

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -93,6 +93,16 @@ Example:
 $ BUILDCACHE_REMOTE=redis://my-redis-server:6379 buildcache g++ -c -O2 hello.cpp -o hello.o
 ```
 
+### HTTP
+
+The HTTP storage backend works with any HTTP server which allows `GET` and `PUT`
+requests on the configured path.
+
+Example:
+```bash
+$ BUILDCACHE_REMOTE=http://my-http-server:9000/my-buildcache-path buildcache g++ -c -O2 hello.cpp -o hello.o
+```
+
 ### S3
 
 [S3](https://en.wikipedia.org/wiki/Amazon_S3) is an open HTTP based protocol

--- a/src/cache/CMakeLists.txt
+++ b/src/cache/CMakeLists.txt
@@ -29,6 +29,8 @@ set(CACHE_SRCS
   data_store.hpp
   local_cache.cpp
   local_cache.hpp
+  http_cache_provider.cpp
+  http_cache_provider.hpp
   redis_cache_provider.cpp
   redis_cache_provider.hpp
   remote_cache.cpp
@@ -50,9 +52,9 @@ if(HAS_S3)
 endif()
 
 add_library(cache ${CACHE_SRCS})
-target_link_libraries(cache base config hiredis)
+target_link_libraries(cache base config hiredis HTTPRequest)
 if(HAS_S3)
-  target_link_libraries(cache cpp-base64 HTTPRequest)
+  target_link_libraries(cache cpp-base64)
   target_compile_definitions(cache PUBLIC ENABLE_S3)
 endif()
 

--- a/src/cache/http_cache_provider.cpp
+++ b/src/cache/http_cache_provider.cpp
@@ -1,0 +1,214 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2019 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#include <base/compressor.hpp>
+#include <base/debug_utils.hpp>
+#include <base/file_utils.hpp>
+#include <cache/http_cache_provider.hpp>
+#include <config/configuration.hpp>
+
+#ifdef _WIN32
+#undef NOMINMAX
+#include <HTTPRequest.hpp>
+#undef log
+#undef ERROR
+#else
+#include <HTTPRequest.hpp>
+#endif
+
+#include <sstream>
+#include <stdexcept>
+
+namespace bcache {
+
+namespace {
+// Name of the cache entry file.
+const std::string CACHE_ENTRY_FILE_NAME = ".entry";
+
+// The prefix (namespace) for BuildCache keys.
+const std::string KEY_PREFIX = "buildcache";
+
+std::string remote_key_name(const std::string& hash_str, const std::string& file) {
+  return KEY_PREFIX + "_" + hash_str + "_" + file;
+}
+
+}  // namespace
+
+http_cache_provider_t::http_cache_provider_t() {
+}
+
+http_cache_provider_t::~http_cache_provider_t() {
+  disconnect();
+}
+
+bool http_cache_provider_t::connect(const std::string& host_description) {
+  // Decode the host description.
+  if (!parse_host_description(host_description, m_host, m_port, m_path)) {
+    return false;
+  }
+
+  // The default port for HTTP is 80 (other services, such as MinIO, may use other ports).
+  if (m_port < 0) {
+    m_port = 80;
+  }
+
+  // If the path is non-empty, it needs to start with a slash.
+  if ((!m_path.empty()) && m_path[0] != '/') {
+    m_path = "/" + m_path;
+  }
+
+  m_ready_for_action = true;
+  return true;
+}
+
+bool http_cache_provider_t::is_connected() const {
+  return m_ready_for_action;
+}
+
+void http_cache_provider_t::disconnect() {
+  m_ready_for_action = false;
+}
+
+std::string http_cache_provider_t::get_object_url(const std::string& key) {
+  std::ostringstream ss;
+  ss << "http://" << m_host << ":" << m_port << m_path << "/" << key;
+  return ss.str();
+}
+
+cache_entry_t http_cache_provider_t::lookup(const hasher_t::hash_t& hash) {
+  const auto key = remote_key_name(hash.as_string(), CACHE_ENTRY_FILE_NAME);
+  try {
+    // Try to get the cache entry item from the remote cache.
+    return cache_entry_t::deserialize(get_data(key));
+  } catch (const std::exception& e) {
+    // We most likely had a cache miss.
+    debug::log(debug::log_level_t::DEBUG) << e.what();
+    return cache_entry_t();
+  }
+}
+
+void http_cache_provider_t::add(const hasher_t::hash_t& hash,
+                                const cache_entry_t& entry,
+                                const std::map<std::string, expected_file_t>& expected_files) {
+  const auto hash_str = hash.as_string();
+
+  // Upload (and optinally compress) the files to the remote cache.
+  for (const auto& file_id : entry.file_ids()) {
+    const auto& source_path = expected_files.at(file_id).path();
+
+    // Read the data from the source file.
+    auto data = file::read(source_path);
+
+    // Compress?
+    if (entry.compression_mode() == cache_entry_t::comp_mode_t::ALL) {
+      debug::log(debug::DEBUG) << "Compressing " << source_path << "...";
+      data = comp::compress(data);
+    }
+
+    // Upload the data.
+    const auto key = remote_key_name(hash_str, file_id);
+    set_data(key, data);
+  }
+
+  // Create a cache entry file.
+  const auto key = remote_key_name(hash_str, CACHE_ENTRY_FILE_NAME);
+  set_data(key, entry.serialize());
+}
+
+void http_cache_provider_t::get_file(const hasher_t::hash_t& hash,
+                                     const std::string& source_id,
+                                     const std::string& target_path,
+                                     const bool is_compressed) {
+  const auto key = remote_key_name(hash.as_string(), source_id);
+  auto data = get_data(key);
+  if (is_compressed) {
+    data = comp::decompress(data);
+  }
+  file::write(data, target_path);
+}
+
+std::string http_cache_provider_t::get_path() const {
+  return m_path;
+}
+
+std::vector<std::string> http_cache_provider_t::get_header(const std::string& /* method */,
+                                                           const std::string& /* key */) const {
+  const std::string content_type = "application/octet-stream";
+  return {"Content-Type: " + content_type};
+}
+
+std::string http_cache_provider_t::get_data(const std::string& key) {
+  if (!is_connected()) {
+    throw std::runtime_error("Can't GET from a disconnected context");
+  }
+
+  // Gather information for this request.
+  const std::string method = "GET";
+  const auto http_header = get_header(method, key);
+
+  // Perform the HTTP request.
+  const auto url = get_object_url(key);
+  http::Request request(url);
+  http::Response response = request.send(method, "", http_header);
+
+  // A successful response must have the code 200.
+  if (response.status != http::Response::Ok) {
+    std::ostringstream ss;
+    if (response.status == http::Response::NotFound) {
+      ss << "File not found on HTTP remote: " << key;
+    } else {
+      ss << "HTTP remote responded (" << response.status << "): " << response.body.data()
+         << " (URL: " << url << ")";
+    }
+    throw std::runtime_error(ss.str());
+  }
+
+  std::string data(response.body.begin(), response.body.end());
+  debug::log(debug::DEBUG) << "Completed HTTP GET request: " << url << " (" << data.size()
+                           << " bytes)";
+
+  return data;
+}
+
+void http_cache_provider_t::set_data(const std::string& key, const std::string& data) {
+  if (!is_connected()) {
+    throw std::runtime_error("Can't PUT to a disconnected context");
+  }
+
+  // Gather information for this request.
+  const std::string method = "PUT";
+  auto http_header = get_header(method, key);
+
+  // Perform the HTTP request.
+  const auto url = get_object_url(key);
+  http::Request request(url);
+  http::Response response = request.send(method, data, http_header);
+
+  // A successful response must have the code 200 or 201.
+  if (response.status != http::Response::Ok && response.status != http::Response::Created) {
+    std::ostringstream ss;
+    ss << "HTTP remote responded (" << response.status << "): " << response.body.data()
+       << " (URL: " << url << ")";
+    throw std::runtime_error(ss.str());
+  }
+
+  debug::log(debug::DEBUG) << "Completed HTTP PUT request: " << url;
+}
+
+}  // namespace bcache

--- a/src/cache/http_cache_provider.hpp
+++ b/src/cache/http_cache_provider.hpp
@@ -1,0 +1,88 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2019 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#ifndef BUILDCACHE_HTTP_CACHE_PROVIDER_HPP_
+#define BUILDCACHE_HTTP_CACHE_PROVIDER_HPP_
+
+#include <cache/remote_cache_provider.hpp>
+
+namespace bcache {
+
+class http_cache_provider_t : public remote_cache_provider_t {
+public:
+  http_cache_provider_t();
+  ~http_cache_provider_t() override;
+
+  // Implementation of the remote_cache_provider_t interface.
+  bool connect(const std::string& host_description) override;
+  bool is_connected() const override;
+  cache_entry_t lookup(const hasher_t::hash_t& hash) override;
+  void add(const hasher_t::hash_t& hash,
+           const cache_entry_t& entry,
+           const std::map<std::string, expected_file_t>& expected_files) override;
+  void get_file(const hasher_t::hash_t& hash,
+                const std::string& source_id,
+                const std::string& target_path,
+                const bool is_compressed) override;
+
+protected:
+  /// @brief Get the path of the destination URL.
+  /// @returns the path of the destination.
+  std::string get_path() const;
+
+private:
+  /// @brief Get the headers for the HTTP request.
+  /// @param method The HTTP method.
+  /// @param key The full name of the object.
+  /// @returns a list of headers.
+  virtual std::vector<std::string> get_header(const std::string& method,
+                                              const std::string& key) const;
+
+  /// @brief Disconnect (usually as a result of an error).
+  void disconnect();
+
+  /// @brief Get the full URL for a given object.
+  /// @param key The full name of the object.
+  /// @returns the full URL for the object.
+  std::string get_object_url(const std::string& key);
+
+  /// @brief Get a binary data blob from the remote cache.
+  /// @param key The unique key that identifies the data.
+  /// @returns the data as a string object.
+  /// @throws runtime_error if the data could not be retrieved (e.g. the key does not exist in the
+  /// remote cache).
+  std::string get_data(const std::string& key);
+
+  /// @brief Set a binary data blob in the remote cache.
+  /// @param key The unique key that identifies the data.
+  /// @param data The data as a string object.
+  /// @throws runtime_error if the data could not be retrieved (e.g. the key does not exist in the
+  /// remote cache).
+  void set_data(const std::string& key, const std::string& data);
+
+  std::string m_host;
+  std::string m_path;
+  int m_port;
+
+  bool m_ready_for_action = false;
+};
+
+}  // namespace bcache
+
+#endif  // BUILDCACHE_S3_CACHE_PROVIDER_HPP_

--- a/src/cache/remote_cache.cpp
+++ b/src/cache/remote_cache.cpp
@@ -20,6 +20,7 @@
 #include <cache/remote_cache.hpp>
 
 #include <base/debug_utils.hpp>
+#include <cache/http_cache_provider.hpp>
 #include <cache/redis_cache_provider.hpp>
 #include <config/configuration.hpp>
 
@@ -71,7 +72,9 @@ bool remote_cache_t::connect() {
 
   // Select an apropriate cache provider.
   m_provider = nullptr;
-  if (protocol == "redis") {
+  if (protocol == "http") {
+    m_provider = new http_cache_provider_t();
+  } else if (protocol == "redis") {
     m_provider = new redis_cache_provider_t();
 #ifdef ENABLE_S3
   } else if (protocol == "s3") {

--- a/src/cache/s3_cache_provider.cpp
+++ b/src/cache/s3_cache_provider.cpp
@@ -17,21 +17,10 @@
 //  3. This notice may not be removed or altered from any source distribution.
 //--------------------------------------------------------------------------------------------------
 
-#include <base/compressor.hpp>
 #include <base/debug_utils.hpp>
-#include <base/file_utils.hpp>
 #include <base/hmac.hpp>
 #include <cache/s3_cache_provider.hpp>
 #include <config/configuration.hpp>
-
-#ifdef _WIN32
-#undef NOMINMAX
-#include <HTTPRequest.hpp>
-#undef log
-#undef ERROR
-#else
-#include <HTTPRequest.hpp>
-#endif
 
 #include <cpp-base64/base64.h>
 #include <ctime>
@@ -41,24 +30,14 @@
 
 namespace bcache {
 
-namespace {
-// Name of the cache entry file.
-const std::string CACHE_ENTRY_FILE_NAME = ".entry";
-
-// The prefix (namespace) for BuildCache keys.
-const std::string KEY_PREFIX = "buildcache";
-
-std::string remote_key_name(const std::string& hash_str, const std::string& file) {
-  return KEY_PREFIX + "_" + hash_str + "_" + file;
-}
-
 std::string get_date_rfc2616_gmt() {
   // TODO(m): setlocale() is not guaranteed to be thread safe. Can we do this in a more thread safe
   // manner?
 
   // Set the locale to "C" (and save old locale).
   const auto* old_locale_ptr = ::setlocale(LC_ALL, nullptr);
-  const auto old_locale = old_locale_ptr ? std::string(::setlocale(LC_ALL, nullptr)) : std::string();
+  const auto old_locale =
+      old_locale_ptr ? std::string(::setlocale(LC_ALL, nullptr)) : std::string();
   ::setlocale(LC_ALL, "C");
 
   // Get the current date & time.
@@ -76,31 +55,8 @@ std::string get_date_rfc2616_gmt() {
 
   return std::string(&buf[0]);
 }
-}  // namespace
-
-s3_cache_provider_t::s3_cache_provider_t() {
-}
-
-s3_cache_provider_t::~s3_cache_provider_t() {
-  disconnect();
-}
 
 bool s3_cache_provider_t::connect(const std::string& host_description) {
-  // Decode the host description.
-  if (!parse_host_description(host_description, m_host, m_port, m_path)) {
-    return false;
-  }
-
-  // The default port for AWS S3 is 80 (other services, such as MinIO, may use other ports).
-  if (m_port < 0) {
-    m_port = 80;
-  }
-
-  // If the path is non-empty, it needs to start with a slash.
-  if ((!m_path.empty()) && m_path[0] != '/') {
-    m_path = "/" + m_path;
-  }
-
   // Get the access keys.
   if (config::s3_access().empty() || config::s3_secret().empty()) {
     debug::log(debug::ERROR)
@@ -110,158 +66,30 @@ bool s3_cache_provider_t::connect(const std::string& host_description) {
   m_access = config::s3_access();
   m_secret = config::s3_secret();
 
-  m_ready_for_action = true;
-  return true;
+  return http_cache_provider_t::connect(host_description);
 }
 
-bool s3_cache_provider_t::is_connected() const {
-  return m_ready_for_action;
+std::vector<std::string> s3_cache_provider_t::get_header(const std::string& method,
+                                                         const std::string& key) const {
+  // Gather information for this request.
+  const std::string date_formatted = get_date_rfc2616_gmt();
+  const std::string relative_path = get_path() + "/" + key;
+  const std::string content_type = "application/octet-stream";
+
+  // Generate a signature based on the S3 secret key.
+  const std::string string_to_sign =
+      method + "\n\n" + content_type + "\n" + date_formatted + "\n" + relative_path;
+  const auto signature = sign_string(string_to_sign);
+
+  return {"Date: " + date_formatted,
+          "Content-Type: " + content_type,
+          "Authorization: AWS " + m_access + ":" + signature};
 }
 
-void s3_cache_provider_t::disconnect() {
-  m_ready_for_action = false;
-}
-
-std::string s3_cache_provider_t::sign_string(const std::string& str) {
+std::string s3_cache_provider_t::sign_string(const std::string& str) const {
   const auto hmac = sha1_hmac(m_secret, str);
   return base64_encode(reinterpret_cast<const unsigned char*>(hmac.data()),
                        static_cast<unsigned int>(hmac.size()));
-}
-
-std::string s3_cache_provider_t::get_object_url(const std::string& key) {
-  std::ostringstream ss;
-  ss << "http://" << m_host << ":" << m_port << m_path << "/" << key;
-  return ss.str();
-}
-
-cache_entry_t s3_cache_provider_t::lookup(const hasher_t::hash_t& hash) {
-  const auto key = remote_key_name(hash.as_string(), CACHE_ENTRY_FILE_NAME);
-  try {
-    // Try to get the cache entry item from the remote cache.
-    return cache_entry_t::deserialize(get_data(key));
-  } catch (const std::exception& e) {
-    // We most likely had a cache miss.
-    debug::log(debug::log_level_t::DEBUG) << e.what();
-    return cache_entry_t();
-  }
-}
-
-void s3_cache_provider_t::add(const hasher_t::hash_t& hash,
-                              const cache_entry_t& entry,
-                              const std::map<std::string, expected_file_t>& expected_files) {
-  const auto hash_str = hash.as_string();
-
-  // Upload (and optinally compress) the files to the remote cache.
-  for (const auto& file_id : entry.file_ids()) {
-    const auto& source_path = expected_files.at(file_id).path();
-
-    // Read the data from the source file.
-    auto data = file::read(source_path);
-
-    // Compress?
-    if (entry.compression_mode() == cache_entry_t::comp_mode_t::ALL) {
-      debug::log(debug::DEBUG) << "Compressing " << source_path << "...";
-      data = comp::compress(data);
-    }
-
-    // Upload the data.
-    const auto key = remote_key_name(hash_str, file_id);
-    set_data(key, data);
-  }
-
-  // Create a cache entry file.
-  const auto key = remote_key_name(hash_str, CACHE_ENTRY_FILE_NAME);
-  set_data(key, entry.serialize());
-}
-
-void s3_cache_provider_t::get_file(const hasher_t::hash_t& hash,
-                                   const std::string& source_id,
-                                   const std::string& target_path,
-                                   const bool is_compressed) {
-  const auto key = remote_key_name(hash.as_string(), source_id);
-  auto data = get_data(key);
-  if (is_compressed) {
-    data = comp::decompress(data);
-  }
-  file::write(data, target_path);
-}
-
-std::string s3_cache_provider_t::get_data(const std::string& key) {
-  if (!is_connected()) {
-    throw std::runtime_error("Can't GET from a disconnected context");
-  }
-
-  // Gather information for this request.
-  const std::string date_formatted = get_date_rfc2616_gmt();
-  const std::string relative_path = m_path + "/" + key;
-  const std::string content_type = "application/octet-stream";
-
-  // Generate a signature based on the S3 secret key.
-  const std::string string_to_sign =
-      "GET\n\n" + content_type + "\n" + date_formatted + "\n" + relative_path;
-  const auto signature = sign_string(string_to_sign);
-
-  // Perform the HTTP request.
-  const auto url = get_object_url(key);
-  http::Request request(url);
-  http::Response response = request.send("GET",
-                                         "",
-                                         {"Date: " + date_formatted,
-                                          "Content-Type: " + content_type,
-                                          "Authorization: AWS " + m_access + ":" + signature});
-
-  // A successful response must have the code 200.
-  if (response.status != http::Response::Ok) {
-    std::ostringstream ss;
-    if (response.status == http::Response::NotFound) {
-      ss << "File not found on S3 remote: " << key;
-    } else {
-      ss << "S3 remote responded (" << response.status << "): " << response.body.data()
-         << " (URL: " << url << ")";
-    }
-    throw std::runtime_error(ss.str());
-  }
-
-  std::string data(response.body.begin(), response.body.end());
-  debug::log(debug::DEBUG) << "Completed HTTP GET request: " << url << " (" << data.size()
-                           << " bytes)";
-
-  return data;
-}
-
-void s3_cache_provider_t::set_data(const std::string& key, const std::string& data) {
-  if (!is_connected()) {
-    throw std::runtime_error("Can't PUT to a disconnected context");
-  }
-
-  // Gather information for this request.
-  const std::string date_formatted = get_date_rfc2616_gmt();
-  const std::string relative_path = m_path + "/" + key;
-  const std::string content_type = "application/octet-stream";
-
-  // Generate a signature based on the S3 secret key.
-  const std::string string_to_sign =
-      "PUT\n\n" + content_type + "\n" + date_formatted + "\n" + relative_path;
-  const auto signature = sign_string(string_to_sign);
-
-  // Perform the HTTP request.
-  const auto url = get_object_url(key);
-  http::Request request(url);
-  http::Response response = request.send("PUT",
-                                         data,
-                                         {"Date: " + date_formatted,
-                                          "Content-Type: " + content_type,
-                                          "Authorization: AWS " + m_access + ":" + signature});
-
-  // A successful response must have the code 200 or 201.
-  if (response.status != http::Response::Ok && response.status != http::Response::Created) {
-    std::ostringstream ss;
-    ss << "S3 remote responded (" << response.status << "): " << response.body.data()
-       << " (URL: " << url << ")";
-    throw std::runtime_error(ss.str());
-  }
-
-  debug::log(debug::DEBUG) << "Completed HTTP PUT request: " << url;
 }
 
 }  // namespace bcache

--- a/src/cache/s3_cache_provider.hpp
+++ b/src/cache/s3_cache_provider.hpp
@@ -20,62 +20,26 @@
 #ifndef BUILDCACHE_S3_CACHE_PROVIDER_HPP_
 #define BUILDCACHE_S3_CACHE_PROVIDER_HPP_
 
-#include <cache/remote_cache_provider.hpp>
+#include <cache/http_cache_provider.hpp>
 
 namespace bcache {
 
-class s3_cache_provider_t : public remote_cache_provider_t {
+class s3_cache_provider_t : public http_cache_provider_t {
 public:
-  s3_cache_provider_t();
-  ~s3_cache_provider_t() override;
-
-  // Implementation of the remote_cache_provider_t interface.
+  // Override S3 specific parts of the http_cache_provider_t.
   bool connect(const std::string& host_description) override;
-  bool is_connected() const override;
-  cache_entry_t lookup(const hasher_t::hash_t& hash) override;
-  void add(const hasher_t::hash_t& hash,
-           const cache_entry_t& entry,
-           const std::map<std::string, expected_file_t>& expected_files) override;
-  void get_file(const hasher_t::hash_t& hash,
-                const std::string& source_id,
-                const std::string& target_path,
-                const bool is_compressed) override;
 
 private:
-  /// @brief Disconnect (usually as a result of an error).
-  void disconnect();
-
   /// @brief Sign a string (to create an AWS authorization string).
   /// @param str The string to sign.
   /// @returns the signature of the string.
-  std::string sign_string(const std::string& str);
+  std::string sign_string(const std::string& str) const;
 
-  /// @brief Get the full URL for a given object.
-  /// @param key The full name of the object.
-  /// @returns the full URL for the object.
-  std::string get_object_url(const std::string& key);
-
-  /// @brief Get a binary data blob from the remote cache.
-  /// @param key The unique key that identifies the data.
-  /// @returns the data as a string object.
-  /// @throws runtime_error if the data could not be retrieved (e.g. the key does not exist in the
-  /// remote cache).
-  std::string get_data(const std::string& key);
-
-  /// @brief Set a binary data blob in the remote cache.
-  /// @param key The unique key that identifies the data.
-  /// @param data The data as a string object.
-  /// @throws runtime_error if the data could not be retrieved (e.g. the key does not exist in the
-  /// remote cache).
-  void set_data(const std::string& key, const std::string& data);
+  std::vector<std::string> get_header(const std::string& method,
+                                      const std::string& key) const override;
 
   std::string m_access;
   std::string m_secret;
-  std::string m_host;
-  std::string m_path;
-  int m_port;
-
-  bool m_ready_for_action = false;
 };
 
 }  // namespace bcache

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -246,6 +246,7 @@ std::unique_ptr<bcache::program_wrapper_t> find_suitable_wrapper(
   std::cout << "\nSupported back ends:\n";
   std::cout << "  local - Local file system based cache (level 1)\n";
   std::cout << "  Redis - Remote in-memory cache (level 2)\n";
+  std::cout << "  HTTP  - Remote webdav cache (level 2)\n";
 #ifdef ENABLE_S3
   std::cout << "  S3    - Remote object storage based cache (level 2)\n";
 #endif


### PR DESCRIPTION
We'd like to use plain HTTP for remote object storage without
S3 specific calculations.