### PR TITLE
Trim whitespace characters (trailing CR) from MSVC response files

### DIFF
--- a/src/base/unicode_utils.cpp
+++ b/src/base/unicode_utils.cpp
@@ -111,6 +111,11 @@ void ucs2_char_to_utf8_char(const wchar_t ucs2_char, char* utf8_token) {
   }
 }
 #endif  // USE_CPP11_CODECVT
+
+bool is_whitespace(const char c) {
+  // TODO(m): Add more white space characters.
+  return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+}
 }  // namespace
 
 #if defined(USE_CPP11_CODECVT)
@@ -174,5 +179,28 @@ std::string lower_case(const std::string& str) {
     result[i] = in;
   }
   return result;
+}
+
+std::string lstrip(const std::string& str) {
+  const auto original_len = str.size();
+  auto pos = std::string::size_type(0);
+  while (pos < original_len && is_whitespace(str[pos])) {
+    ++pos;
+  }
+  return pos != 0 ? str.substr(pos) : str;
+}
+
+std::string rstrip(const std::string& str) {
+  const auto original_len = str.size();
+  auto len = original_len;
+  while (len > 0 && is_whitespace(str[len - 1])) {
+    --len;
+  }
+  return len < original_len ? str.substr(0, len) : str;
+}
+
+std::string strip(const std::string& str) {
+  // TODO(m): We could optimize this to only use a single call to substr.
+  return lstrip(rstrip(str));
 }
 }  // namespace bcache

--- a/src/base/unicode_utils.hpp
+++ b/src/base/unicode_utils.hpp
@@ -38,6 +38,21 @@ std::wstring utf8_to_ucs2(const std::string& str8);
 /// @returns a lower case version of the input string.
 /// @note This function currently only works on the ASCII subset of Unicode.
 std::string lower_case(const std::string& str);
+
+/// @brief Strip leading white space characters.
+/// @param str The string to strip.
+/// @returns a string without leading white space characters.
+std::string lstrip(const std::string& str);
+
+/// @brief Strip trailing white space characters.
+/// @param str The string to strip.
+/// @returns a string without trailing white space characters.
+std::string rstrip(const std::string& str);
+
+/// @brief Strip leading and trailing white space characters.
+/// @param str The string to strip.
+/// @returns a string without leading or trailing white space characters.
+std::string strip(const std::string& str);
 }  // namespace bcache
 
 #endif  // BUILDCACHE_UNICODE_UTILS_HPP_

--- a/src/wrappers/msvc_wrapper.cpp
+++ b/src/wrappers/msvc_wrapper.cpp
@@ -173,7 +173,7 @@ void msvc_wrapper_t::resolve_args() {
                                   new std::codecvt_utf16<wchar_t, 0x10ffff, std::consume_header>));
           std::wstring wline;
           while (std::getline(wfile, wline)) {
-            m_resolved_args += string_list_t::split_args(ucs2_to_utf8(wline));
+            m_resolved_args += string_list_t::split_args(strip(ucs2_to_utf8(wline)));
           }
         } else {
           // Assume UTF-8.
@@ -181,7 +181,7 @@ void msvc_wrapper_t::resolve_args() {
           file.seekg(0);
           std::string line;
           while (std::getline(file, line)) {
-            m_resolved_args += string_list_t::split_args(line);
+            m_resolved_args += string_list_t::split_args(strip(line));
           }
         }
       }
@@ -207,7 +207,7 @@ std::map<std::string, expected_file_t> msvc_wrapper_t::get_build_files() {
   std::map<std::string, expected_file_t> files;
   auto found_object_file = false;
   for (const auto& arg : m_resolved_args) {
-    if (arg_starts_with(arg, "Fo") && (is_object_file(file::get_extension(arg)))) {
+    if (arg_starts_with(arg, "Fo") && is_object_file(file::get_extension(arg))) {
       if (found_object_file) {
         throw std::runtime_error("Only a single target object file can be specified.");
       }


### PR DESCRIPTION
This fixes problems with properly parsing arguments and identifying object files (for instance).