### PR TITLE
Add -fdirectives-only for gcc to speed up preprocessor

### DIFF
--- a/src/wrappers/gcc_wrapper.hpp
+++ b/src/wrappers/gcc_wrapper.hpp
@@ -27,12 +27,6 @@ namespace bcache {
 class gcc_wrapper_t : public program_wrapper_t {
 public:
   /// @brief Compatible mode.
-  enum class compatible_mode_t {
-    NOT_SPECIFIED = 0,  ///< Don't use any specific flags
-    GCC = 1,            ///< Can use GCC compatible flags
-    CLANG = 2,          ///< Can use Clang compatible flags
-  };
-
   gcc_wrapper_t(const file::exe_path_t& exe_path, const string_list_t& args);
 
   bool can_handle_command() override;
@@ -46,17 +40,35 @@ protected:
   string_list_t get_input_files() override;
   std::string preprocess_source() override;
   string_list_t get_implicit_input_files() override;
+
+  /// @brief Get whether -D flags are consumed during preprocess step
+  ///
+  /// Some compilers support an optimization to not expand macro definitions
+  /// during a preprocess step. When determining relevent arguments for hashing,
+  /// it is important to note whether the -D command line flag will be consumed
+  /// during preprocess and therefore result in changes to the preprocess output
+  /// or not.
+  /// @returns true if preprocess step will consume -D arguments
+  ///
+  /// @note Only used in preprocess mode
   virtual bool uses_defines_in_preprocess() const;
 
   string_list_t m_resolved_args;
   string_list_t m_implicit_input_files;
-  compatible_mode_t m_compatible_mode;
 
 private:
+  enum class compatible_mode_t {
+    NOT_SPECIFIED = 0,  ///< Don't use any specific flags
+    GCC = 1,            ///< Can use GCC compatible flags
+    CLANG = 2,          ///< Can use Clang compatible flags
+  };
+  compatible_mode_t m_compatible_mode = compatible_mode_t::NOT_SPECIFIED;
+
   void resolve_args() override;
   string_list_t parse_args(const string_list_t& args);
   string_list_t parse_response_file(const std::string& filename);
   virtual string_list_t get_include_files(const std::string& std_err) const;
+  virtual string_list_t make_preprocessor_cmd(const std::string& preprocessed_file) const;
 };
 }  // namespace bcache
 #endif  // BUILDCACHE_GCC_WRAPPER_HPP_

--- a/src/wrappers/gcc_wrapper.hpp
+++ b/src/wrappers/gcc_wrapper.hpp
@@ -26,6 +26,13 @@ namespace bcache {
 /// @brief A program wrapper for GCC and GCC-like C/C++ compilers.
 class gcc_wrapper_t : public program_wrapper_t {
 public:
+  /// @brief Compatible mode.
+  enum class compatible_mode_t {
+    NOT_SPECIFIED = 0,  ///< Don't use any specific flags
+    GCC = 1,            ///< Can use GCC compatible flags
+    CLANG = 2,          ///< Can use Clang compatible flags
+  };
+
   gcc_wrapper_t(const file::exe_path_t& exe_path, const string_list_t& args);
 
   bool can_handle_command() override;
@@ -39,9 +46,11 @@ protected:
   string_list_t get_input_files() override;
   std::string preprocess_source() override;
   string_list_t get_implicit_input_files() override;
+  virtual bool uses_defines_in_preprocess() const;
 
   string_list_t m_resolved_args;
   string_list_t m_implicit_input_files;
+  compatible_mode_t m_compatible_mode;
 
 private:
   void resolve_args() override;


### PR DESCRIPTION
Also adds -frewrite-includes for clang

This can drastically reduce the amount of work needed to be done by the preprocessor by limiting the preprocessor to only a subset of the directives and avoiding many macro expansions.
#include and #define and #ifdef are still resolved

On a large codebase with thousands of cpp files, this sped up local, warm, cache hits 4x when in preprocessor mode (direct mode is still much faster)