### PR TITLE
Windows: improve file_utils.cpp path functions

### DIFF
--- a/src/base/file_utils.cpp
+++ b/src/base/file_utils.cpp
@@ -260,38 +260,39 @@ std::string append_path(const std::string& path, const char* append) {
 
 std::string canonicalize_path(const std::string& path) {
 #ifdef _WIN32
-  std::string result = path;
-
-  // Start by converting forward slashes to back slashes (GetFullPathNameW does not do that).
-  for (size_t i = 0; i < result.size(); ++i) {
-    const auto c = result[i];
-    result[i] = (c == '/') ? '\\' : c;
-  }
+  std::string result;
 
   // Use a Win32 API function to resolve as much as possible. Unfortunately there does not seem to
   // be a single Win32 API function that can give sane results (hence the pre/post processing).
   {
-    wchar_t buf[MAX_PATH];
-    const DWORD l = GetFullPathNameW(utf8_to_ucs2(result).c_str(), MAX_PATH, &buf[0], NULL);
-    if (l == 0 || l >= MAX_PATH) {
+    const std::wstring ucs2 = utf8_to_ucs2(path);
+    wchar_t buf[MAX_PATH + 1];
+    const DWORD buf_size = std::extent<decltype(buf)>::value;
+    const DWORD full_path_size = GetFullPathNameW(ucs2.c_str(), buf_size, &buf[0], NULL);
+    if (full_path_size > 0 && full_path_size < buf_size) {
+      result = ucs2_to_utf8(buf, buf + full_path_size);
+    } else if (full_path_size >= buf_size) {
+      // Buffer is too small, dynamically allocate bigger buffer.
+      std::wstring final_path(full_path_size - 1, 0);  // terminating null ch is added automatically
+      GetFullPathNameW(ucs2.c_str(), full_path_size, &final_path[0], NULL);
+      result = ucs2_to_utf8(final_path);
+    } else {
       throw std::runtime_error("Unable to canonicalize the path " + result);
     }
-    result = ucs2_to_utf8(std::wstring(buf));
   }
 
-  // Drop trailing back slash.
-  {
-    const auto last = static_cast<int>(result.length()) - 1;
+  if (!result.empty()) {
+    // Drop trailing back slash.
+    const size_t last = result.size() - 1;
     if (last >= 2 && result[last] == '\\' && result[last - 1] != ':') {
-      result = result.substr(0, last);
+      result.pop_back();
+    }
+    // Convert drive letters to uppercase.
+    if (result.length() >= 2U && result[1] == ':') {
+      result[0] = static_cast<char>(std::toupper(result[0]));
     }
   }
 
-  // Convert drive letters to uppercase.
-  if (result.length() >= 2U && result[1] == ':') {
-    const auto drive_char = result.substr(0, 1);
-    result[0] = upper_case(drive_char)[0];
-  }
 #else
   std::string result = path;
 

--- a/src/base/file_utils.cpp
+++ b/src/base/file_utils.cpp
@@ -466,13 +466,22 @@ std::string resolve_path(const std::string& path) {
                              nullptr);
   if (INVALID_HANDLE_VALUE != handle) {
     std::wstring resolved_path;
-    auto resolved_size = GetFinalPathNameByHandleW(handle, nullptr, 0, FILE_NAME_NORMALIZED);
-    resolved_path.resize(resolved_size - 1);  // terminating null character is added automatically
-
-    GetFinalPathNameByHandleW(handle, &resolved_path[0], resolved_size, FILE_NAME_NORMALIZED);
+    wchar_t buffer[MAX_PATH + 1];
+    const DWORD buf_size = std::extent<decltype(buffer)>::value;
+    auto resolved_size = GetFinalPathNameByHandleW(handle, buffer, buf_size, FILE_NAME_NORMALIZED);
+    if (resolved_size < buf_size) {
+      // In this case the resolved_size doesn't include terminating null character.
+      resolved_path.assign(buffer, resolved_size);
+    } else {
+      // Array is too small to fit the path, allocate buffer dynamically to fit the path.
+      resolved_path.resize(resolved_size - 1);  // terminating null character is added automatically
+      GetFinalPathNameByHandleW(handle, &resolved_path[0], resolved_size, FILE_NAME_NORMALIZED);
+    }
     CloseHandle(handle);
-    if (resolved_path.substr(0, 4) == LR"(\\?\)") {
-      resolved_path = resolved_path.substr(4);
+    const std::wstring prefix(LR"(\\?\)");
+    const bool may_has_prefix = resolved_path.size() >= prefix.size();
+    if (may_has_prefix && resolved_path.compare(0, prefix.size(), prefix) == 0) {
+      resolved_path = resolved_path.substr(prefix.size());
     }
     return ucs2_to_utf8(resolved_path);
   }

--- a/src/base/file_utils.cpp
+++ b/src/base/file_utils.cpp
@@ -359,10 +359,15 @@ std::string get_dir_part(const std::string& path) {
 
 std::string get_temp_dir() {
 #if defined(_WIN32)
-  WCHAR buf[MAX_PATH + 1] = {0};
-  DWORD path_len = GetTempPathW(MAX_PATH + 1, buf);
-  if (path_len > 0) {
-    return canonicalize_path(ucs2_to_utf8(std::wstring(buf, path_len)));
+  WCHAR buf_arr[MAX_PATH + 1];
+  const DWORD buf_arr_size = std::extent<decltype(buf_arr)>::value;
+  const DWORD path_len = GetTempPathW(buf_arr_size, buf_arr);
+  if (path_len > 0 && path_len < buf_arr_size) {
+    return canonicalize_path(ucs2_to_utf8(std::wstring(buf_arr, path_len)));
+  } else if (path_len > 0) {
+    std::wstring buf_str(path_len - 1, 0);  // terminating null character is added automatically
+    GetTempPathW(path_len, &buf_str[0]);
+    return canonicalize_path(ucs2_to_utf8(buf_str));
   }
   return std::string();
 #else

--- a/src/base/unicode_utils.cpp
+++ b/src/base/unicode_utils.cpp
@@ -128,6 +128,15 @@ std::string ucs2_to_utf8(const std::wstring& str16) {
   }
 }
 
+std::string ucs2_to_utf8(const wchar_t* str16_first, const wchar_t* str16_last) {
+  std::wstring_convert<std::codecvt_utf8<wchar_t> > conv;
+  try {
+    return conv.to_bytes(str16_first, str16_last);
+  } catch (...) {
+    return std::string();
+  }
+}
+
 std::wstring utf8_to_ucs2(const std::string& str8) {
   std::wstring_convert<std::codecvt_utf8<wchar_t> > conv;
   try {

--- a/src/base/unicode_utils.cpp
+++ b/src/base/unicode_utils.cpp
@@ -147,9 +147,13 @@ std::wstring utf8_to_ucs2(const std::string& str8) {
 }
 #else
 std::string ucs2_to_utf8(const std::wstring& str16) {
+  return ucs2_to_utf8(str16.c_str(), str16.c_str() + str16.length());
+}
+
+std::string ucs2_to_utf8(const wchar_t* begin, const wchar_t* end) {
   std::string result;
-  const auto* cursor = str16.c_str();
-  const auto* const end = str16.c_str() + str16.length();
+  result.reserve(static_cast<size_t>(std::max(static_cast<int>(end - begin), 0)));
+  auto cursor = begin;
   while (end > cursor) {
     char utf8_sequence[] = {0, 0, 0, 0, 0};
     ucs2_char_to_utf8_char(*cursor, utf8_sequence);

--- a/src/base/unicode_utils.cpp
+++ b/src/base/unicode_utils.cpp
@@ -128,10 +128,10 @@ std::string ucs2_to_utf8(const std::wstring& str16) {
   }
 }
 
-std::string ucs2_to_utf8(const wchar_t* str16_first, const wchar_t* str16_last) {
+std::string ucs2_to_utf8(const wchar_t* begin, const wchar_t* end) {
   std::wstring_convert<std::codecvt_utf8<wchar_t> > conv;
   try {
-    return conv.to_bytes(str16_first, str16_last);
+    return conv.to_bytes(begin, end);
   } catch (...) {
     return std::string();
   }
@@ -153,7 +153,7 @@ std::string ucs2_to_utf8(const std::wstring& str16) {
 std::string ucs2_to_utf8(const wchar_t* begin, const wchar_t* end) {
   std::string result;
   result.reserve(static_cast<size_t>(std::max(static_cast<int>(end - begin), 0)));
-  auto cursor = begin;
+  const auto* cursor = begin;
   while (end > cursor) {
     char utf8_sequence[] = {0, 0, 0, 0, 0};
     ucs2_char_to_utf8_char(*cursor, utf8_sequence);

--- a/src/base/unicode_utils.hpp
+++ b/src/base/unicode_utils.hpp
@@ -28,6 +28,12 @@ namespace bcache {
 /// @returns a UTF-8 encoded string.
 std::string ucs2_to_utf8(const std::wstring& str16);
 
+/// @brief Convert a UCS-2 string to a UTF-8 string.
+/// @param str16_first The UCS-2 encoded wide character string first character.
+/// @param str16_last The UCS-2 encoded wide character string last character.
+/// @returns a UTF-8 encoded string.
+std::string ucs2_to_utf8(const wchar_t* str16_first, const wchar_t* str16_last);
+
 /// @brief Convert a UTF-8 string to a UCS-2 string.
 /// @param str8 The UTF-8 encoded string.
 /// @returns a UCS-2 encoded wide charater string.

--- a/src/base/unicode_utils.hpp
+++ b/src/base/unicode_utils.hpp
@@ -29,10 +29,10 @@ namespace bcache {
 std::string ucs2_to_utf8(const std::wstring& str16);
 
 /// @brief Convert a UCS-2 string to a UTF-8 string.
-/// @param str16_first The UCS-2 encoded wide character string first character.
-/// @param str16_last The UCS-2 encoded wide character string last character.
+/// @param begin The begin of the UCS-2 encoded wide character string.
+/// @param end The end of the UCS-2 encoded wide character string.
 /// @returns a UTF-8 encoded string.
-std::string ucs2_to_utf8(const wchar_t* str16_first, const wchar_t* str16_last);
+std::string ucs2_to_utf8(const wchar_t* begin, const wchar_t* end);
 
 /// @brief Convert a UTF-8 string to a UCS-2 string.
 /// @param str8 The UTF-8 encoded string.


### PR DESCRIPTION
- improve `resolve_path()` performance:
  - call `GetFinalPathNameByHandleW()` only once for the most of the cases
    to improve performance since calling filesystem functions on Windows is
    expensive
  - use `std::string::compare()` which works faster instead of making `substr()`
    just to compare
- improve `canonicalize_path()`, fix for paths > `MAX_PATH`:
  - there is no need to replace slashes with backslashes,
    since `GetFullPathNameW()` returns backslashes
    (checked personally on Windows 10).
  - make function work for paths >= `MAX_PATH`
    by performing second call to `GetFullPathNameW()`
    in case first reported buffer too small
  - don't use `substr()` to remove single char
  - don't use `substr()` to transform single char to upper case
  - add `const wchar_t*` version of `ucs2_to_utf8`
    to prevent unnecessary allocations of `std::wstring`
- improve `get_user_home_dir()`
  - call `GetUserProfileDirectoryW()` only once for the most of the cases,
    since calls to filesystem functions on Windows is expensive.
  - don't allocate memory on heap in most of the cases
- make `get_temp_dir()` work if path > `MAX_PATH`