### PR TITLE
gcc_wrapper: Skip the -MD, -MP and -MF <file> flags.

### DIFF
--- a/src/wrappers/gcc_wrapper.cpp
+++ b/src/wrappers/gcc_wrapper.cpp
@@ -101,6 +101,9 @@ string_list_t make_preprocessor_cmd(const string_list_t& args,
     } else if (arg == "-o") {
       drop_this_arg = true;
       drop_next_arg = true;
+    } else if (arg == "-MF") {
+      drop_this_arg = true;
+      drop_next_arg = true;
     }
     if (!drop_this_arg) {
       preprocess_args += arg;


### PR DESCRIPTION
When the preprocessor command is generated there is really no need to
also emit dependency information. This also fixes the bug where -MF
<file> is present and where buildcache would remove the file to output
dependency information to and substitute it for its own .i temporary
file.