### PR TITLE
gcc_wrapper: Skip the -MF <file> argument.

### DIFF
--- a/src/wrappers/gcc_wrapper.cpp
+++ b/src/wrappers/gcc_wrapper.cpp
@@ -101,6 +101,9 @@ string_list_t make_preprocessor_cmd(const string_list_t& args,
     } else if (arg == "-o") {
       drop_this_arg = true;
       drop_next_arg = true;
+    } else if (arg == "-MF") {
+      drop_this_arg = true;
+      drop_next_arg = true;
     }
     if (!drop_this_arg) {
       preprocess_args += arg;


### PR DESCRIPTION
If the -MF argument is present in the build command, it's because the
caller uses dependency files. If we call the preprocessor command with
-MF at this point, we will overwrite that file including our temporary
preprocessed file in that dependency list. Hence we make sure to skip
that when preprocessing.