### PR TITLE
Add --config param for building Release

### DIFF
--- a/doc/building.md
+++ b/doc/building.md
@@ -9,7 +9,7 @@ BuildCache program:
 $ mkdir build
 $ cd build
 $ cmake -DCMAKE_BUILD_TYPE=Release ../src
-$ cmake --build .
+$ cmake --build . --config Release
 ```
 
 Note: For S3 support on non-macOS/Windows systems you need OpenSSL (e.g. install


### PR DESCRIPTION
By default cmake will build Debug on Windows even if we specified `-DCMAKE_BUILD_TYPE=Release` in the previous step.

This closes #207 