### PR TITLE
Windows: improve file_utils.cpp path functions (take 2)

### DIFF
--- a/src/base/CMakeLists.txt
+++ b/src/base/CMakeLists.txt
@@ -66,10 +66,6 @@ elseif(OPENSSL_FOUND)
   target_compile_definitions(base PRIVATE HAS_OPENSSL)
 endif()
 
-buildcache_add_test(NAME file_utils_test
-                    SOURCES file_utils_test.cpp
-                    LIBRARIES base)
-
 buildcache_add_test(NAME env_utils_test
                     SOURCES env_utils_test.cpp
                     LIBRARIES base)
@@ -78,8 +74,8 @@ buildcache_add_test(NAME file_lock_test
                     SOURCES file_lock_test.cpp
                     LIBRARIES base)
 
-buildcache_add_test(NAME string_list_test
-                    SOURCES string_list_test.cpp
+buildcache_add_test(NAME file_utils_test
+                    SOURCES file_utils_test.cpp
                     LIBRARIES base)
 
 buildcache_add_test(NAME hasher_test
@@ -91,6 +87,14 @@ if(HAS_HMAC)
                       SOURCES hmac_test.cpp
                       LIBRARIES base)
 endif()
+
+buildcache_add_test(NAME string_list_test
+                    SOURCES string_list_test.cpp
+                    LIBRARIES base)
+
+buildcache_add_test(NAME unicode_utils_test
+                    SOURCES unicode_utils_test.cpp
+                    LIBRARIES base)
 
 # This is a special test executable. It is meant to be run as multiple concurrent instances.
 add_executable(file_lock_stresstest

--- a/src/base/unicode_utils.cpp
+++ b/src/base/unicode_utils.cpp
@@ -188,14 +188,27 @@ std::wstring utf8_to_ucs2(const std::string& str8) {
 }
 #endif  // USE_CPP11_CODECVT
 
+int lower_case(const int code) {
+  auto in = code;
+  if (('A' <= in) && (in <= 'Z')) {
+    in += ('a' - 'A');
+  }
+  return in;
+}
+
+int upper_case(const int code) {
+  auto in = code;
+  if (('a' <= in) && (in <= 'z')) {
+    in -= ('a' - 'A');
+  }
+  return in;
+}
+
 std::string lower_case(const std::string& str) {
   std::string result(str.size(), ' ');
   for (std::string::size_type i = 0; i < str.size(); ++i) {
-    auto in = str[i];
-    if (('A' <= in) && (in <= 'Z')) {
-      in += ('a' - 'A');
-    }
-    result[i] = in;
+    // TODO(m): Handle multi-byte UTF-8 sequences.
+    result[i] = static_cast<char>(lower_case(static_cast<int>(str[i])));
   }
   return result;
 }
@@ -203,11 +216,8 @@ std::string lower_case(const std::string& str) {
 std::string upper_case(const std::string& str) {
   std::string result(str.size(), ' ');
   for (std::string::size_type i = 0; i < str.size(); ++i) {
-    auto in = str[i];
-    if (('a' <= in) && (in <= 'z')) {
-      in -= ('a' - 'A');
-    }
-    result[i] = in;
+    // TODO(m): Handle multi-byte UTF-8 sequences.
+    result[i] = static_cast<char>(upper_case(static_cast<int>(str[i])));
   }
   return result;
 }
@@ -234,4 +244,5 @@ std::string strip(const std::string& str) {
   // TODO(m): We could optimize this to only use a single call to substr.
   return lstrip(rstrip(str));
 }
+
 }  // namespace bcache

--- a/src/base/unicode_utils.hpp
+++ b/src/base/unicode_utils.hpp
@@ -39,6 +39,18 @@ std::string ucs2_to_utf8(const wchar_t* begin, const wchar_t* end);
 /// @returns a UCS-2 encoded wide charater string.
 std::wstring utf8_to_ucs2(const std::string& str8);
 
+/// @brief Convert the character to lower case.
+/// @param code The character to convert.
+/// @returns a lower case version of the input character.
+/// @note This function currently only works on the ASCII subset of Unicode.
+int lower_case(const int code);
+
+/// @brief Convert the character to upper case.
+/// @param code The character to convert.
+/// @returns an upper case version of the input character.
+/// @note This function currently only works on the ASCII subset of Unicode.
+int upper_case(const int code);
+
 /// @brief Convert the string to lower case.
 /// @param str The string to convert.
 /// @returns a lower case version of the input string.

--- a/src/base/unicode_utils.hpp
+++ b/src/base/unicode_utils.hpp
@@ -28,6 +28,12 @@ namespace bcache {
 /// @returns a UTF-8 encoded string.
 std::string ucs2_to_utf8(const std::wstring& str16);
 
+/// @brief Convert a UCS-2 string to a UTF-8 string.
+/// @param begin The begin of the UCS-2 encoded wide character string.
+/// @param end The end of the UCS-2 encoded wide character string.
+/// @returns a UTF-8 encoded string.
+std::string ucs2_to_utf8(const wchar_t* begin, const wchar_t* end);
+
 /// @brief Convert a UTF-8 string to a UCS-2 string.
 /// @param str8 The UTF-8 encoded string.
 /// @returns a UCS-2 encoded wide charater string.

--- a/src/base/unicode_utils_test.cpp
+++ b/src/base/unicode_utils_test.cpp
@@ -1,0 +1,179 @@
+//--------------------------------------------------------------------------------------------------
+// Copyright (c) 2021 Marcus Geelnard
+//
+// This software is provided 'as-is', without any express or implied warranty. In no event will the
+// authors be held liable for any damages arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose, including commercial
+// applications, and to alter it and redistribute it freely, subject to the following restrictions:
+//
+//  1. The origin of this software must not be misrepresented; you must not claim that you wrote
+//     the original software. If you use this software in a product, an acknowledgment in the
+//     product documentation would be appreciated but is not required.
+//
+//  2. Altered source versions must be plainly marked as such, and must not be misrepresented as
+//     being the original software.
+//
+//  3. This notice may not be removed or altered from any source distribution.
+//--------------------------------------------------------------------------------------------------
+
+#include <base/unicode_utils.hpp>
+
+#include <doctest/doctest.h>
+
+#include <string>
+
+// Workaround for macOS build errors.
+// See: https://github.com/onqtam/doctest/issues/126
+#include <iostream>
+
+using namespace bcache;
+
+TEST_CASE("ucs2_to_utf8() produces expected results") {
+  SUBCASE("Case 1 - Hello world") {
+    const std::wstring str = L"Hello world";
+    const auto result = ucs2_to_utf8(str);
+    CHECK_EQ(result, "Hello world");
+  }
+
+  SUBCASE("Case 2 - Привет мир") {
+    const std::wstring str{1055, 1088, 1080, 1074, 1077, 1090, 32, 1084, 1080, 1088};
+    const auto result = ucs2_to_utf8(str);
+    CHECK_EQ(result, "Привет мир");
+  }
+}
+
+TEST_CASE("ucs2_to_utf8() with range produces expected results") {
+  SUBCASE("Case 1 - Sub-range") {
+    const std::wstring str = L"Hello world";
+    const auto result = ucs2_to_utf8(&str[6], &str[8]);
+    CHECK_EQ(result, "wo");
+  }
+
+  SUBCASE("Case 2 - Negative range") {
+    const std::wstring str = L"Hello world";
+    const auto result = ucs2_to_utf8(&str[8], &str[6]);
+    CHECK_EQ(result, "");
+  }
+}
+
+TEST_CASE("utf8_to_ucs2() produces expected results") {
+  SUBCASE("Case 1 - Hello world") {
+    const std::string str = "Hello world";
+    const auto result = utf8_to_ucs2(str);
+    CHECK_EQ(result, L"Hello world");
+  }
+
+  SUBCASE("Case 2 - Привет мир") {
+    const std::string str = "Привет мир";
+    const auto result = utf8_to_ucs2(str);
+    const std::wstring expected{1055, 1088, 1080, 1074, 1077, 1090, 32, 1084, 1080, 1088};
+    CHECK_EQ(result, expected);
+  }
+}
+
+TEST_CASE("lower_case() produces expected results") {
+  SUBCASE("Case 1 - Character") {
+    const char c = 'X';
+    const auto result = lower_case(c);
+    CHECK_EQ(result, 'x');
+  }
+
+  SUBCASE("Case 2 - String") {
+    const std::string str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234";
+    const auto result = lower_case(str);
+    CHECK_EQ(result, "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz01234");
+  }
+}
+
+TEST_CASE("upper_case() produces expected results") {
+  SUBCASE("Case 1 - Character") {
+    const char c = 'x';
+    const auto result = upper_case(c);
+    CHECK_EQ(result, 'X');
+  }
+
+  SUBCASE("Case 2 - String") {
+    const std::string str = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz01234";
+    const auto result = upper_case(str);
+    CHECK_EQ(result, "ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWXYZ01234");
+  }
+}
+
+TEST_CASE("lstrip() produces expected results") {
+  SUBCASE("Case 1 - space") {
+    const std::string str = "  Hello world  ";
+    const auto result = lstrip(str);
+    CHECK_EQ(result, "Hello world  ");
+  }
+
+  SUBCASE("Case 2 - tab") {
+    const std::string str = "\t Hello world \t";
+    const auto result = lstrip(str);
+    CHECK_EQ(result, "Hello world \t");
+  }
+
+  SUBCASE("Case 3 - newline") {
+    const std::string str = "\n Hello world \n";
+    const auto result = lstrip(str);
+    CHECK_EQ(result, "Hello world \n");
+  }
+
+  SUBCASE("Case 4 - carriage return") {
+    const std::string str = "\r Hello world \r";
+    const auto result = lstrip(str);
+    CHECK_EQ(result, "Hello world \r");
+  }
+}
+
+TEST_CASE("rstrip() produces expected results") {
+  SUBCASE("Case 1 - space") {
+    const std::string str = "  Hello world  ";
+    const auto result = rstrip(str);
+    CHECK_EQ(result, "  Hello world");
+  }
+
+  SUBCASE("Case 2 - tab") {
+    const std::string str = "\t Hello world \t";
+    const auto result = rstrip(str);
+    CHECK_EQ(result, "\t Hello world");
+  }
+
+  SUBCASE("Case 3 - newline") {
+    const std::string str = "\n Hello world \n";
+    const auto result = rstrip(str);
+    CHECK_EQ(result, "\n Hello world");
+  }
+
+  SUBCASE("Case 4 - carriage return") {
+    const std::string str = "\r Hello world \r";
+    const auto result = rstrip(str);
+    CHECK_EQ(result, "\r Hello world");
+  }
+}
+
+TEST_CASE("strip() produces expected results") {
+  SUBCASE("Case 1 - space") {
+    const std::string str = "  Hello world  ";
+    const auto result = strip(str);
+    CHECK_EQ(result, "Hello world");
+  }
+
+  SUBCASE("Case 2 - tab") {
+    const std::string str = "\t Hello world \t";
+    const auto result = strip(str);
+    CHECK_EQ(result, "Hello world");
+  }
+
+  SUBCASE("Case 3 - newline") {
+    const std::string str = "\n Hello world \n";
+    const auto result = strip(str);
+    CHECK_EQ(result, "Hello world");
+  }
+
+  SUBCASE("Case 4 - carriage return") {
+    const std::string str = "\r Hello world \r";
+    const auto result = strip(str);
+    CHECK_EQ(result, "Hello world");
+  }
+}


### PR DESCRIPTION
- improve `resolve_path()` performance:
  - call `GetFinalPathNameByHandleW()` only once for the most of the cases
    to improve performance since calling filesystem functions on Windows is
    expensive
  - use `std::string::compare()` which works faster instead of making `substr()`
    just to compare
- improve `canonicalize_path()`, fix for paths > `MAX_PATH`:
  - there is no need to replace slashes with backslashes,
    since `GetFullPathNameW()` returns backslashes
    (checked personally on Windows 10).
  - make function work for paths >= `MAX_PATH`
    by performing second call to `GetFullPathNameW()`
    in case first reported buffer too small
  - don't use `substr()` to remove single char
  - don't use `substr()` to transform single char to upper case
  - add `const wchar_t*` version of `ucs2_to_utf8`
    to prevent unnecessary allocations of `std::wstring`
- improve `get_user_home_dir()`
  - call `GetUserProfileDirectoryW()` only once for the most of the cases,
    since calls to filesystem functions on Windows is expensive.
  - don't allocate memory on heap in most of the cases
- make `get_temp_dir()` work if path > `MAX_PATH`

**Note:** This PR supersedes #208 