### PR TITLE
Add support for redis auth

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -30,6 +30,8 @@ The following options control the behavior of BuildCache:
 | `BUILDCACHE_PREFIX` | `prefix` | Prefix command for cache misses | None |
 | `BUILDCACHE_READ_ONLY` | `read_only` | Only read and use the cache without updating it | false |
 | `BUILDCACHE_READ_ONLY_REMOTE` | `read_only_remote` | Only read and use the remote cache without updating it (implied by `BUILDCACHE_READ_ONLY`) | false |
+| `BUILDCACHE_REDIS_USERNAME` | `redis_username` | Redis auth username | None |
+| `BUILDCACHE_REDIS_PASSWORD` | `redis_password` | Redis auth password (username optional) | None |
 | `BUILDCACHE_REMOTE` | `remote` | Address of remote cache server (`protocol://host:port/path`, where `protocol` can be `http`, `redis` or `s3`, and `port` and `path` are optional) | None |
 | `BUILDCACHE_REMOTE_LOCKS` | `remote_locks` | Use a (potentially slower) file locking mechanism that is safe if the local cache is on a fileshare | false |
 | `BUILDCACHE_S3_ACCESS` | `s3_access` | S3 access key | None |

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -99,6 +99,9 @@ To do so, set `BUILDCACHE_REMOTE` to a valid remote server address (see below).
 eviction policies. It is suitable for build systems that produce many small
 object files, such as is typical for C/C++ compilation.
 
+[Authentication](https://redis.io/commands/auth) is supported using 
+`BUILDCACHE_REDIS_PASSWORD` with or without `BUILDCACHE_REDIS_USERNAME`.
+
 Example:
 ```bash
 $ BUILDCACHE_REMOTE=redis://my-redis-server:6379 buildcache g++ -c -O2 hello.cpp -o hello.o

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -70,6 +70,8 @@ bool s_perf = false;
 std::string s_prefix;
 bool s_read_only = false;
 bool s_read_only_remote = false;
+std::string s_redis_username;
+std::string s_redis_password;
 bool s_remote_locks = false;
 std::string s_remote;
 std::string s_s3_access;
@@ -293,6 +295,20 @@ void load_from_file(const std::string& file_name) {
     const auto* node = cJSON_GetObjectItemCaseSensitive(root, "read_only_remote");
     if (cJSON_IsBool(node) != 0) {
       s_read_only_remote = (cJSON_IsTrue(node) != 0);
+    }
+  }
+
+  {
+    const auto* node = cJSON_GetObjectItemCaseSensitive(root, "redis_username");
+    if ((cJSON_IsString(node) != 0) && node->valuestring != nullptr) {
+      s_redis_username = std::string(node->valuestring);
+    }
+  }
+
+  {
+    const auto* node = cJSON_GetObjectItemCaseSensitive(root, "redis_password");
+    if ((cJSON_IsString(node) != 0) && node->valuestring != nullptr) {
+      s_redis_password = std::string(node->valuestring);
     }
   }
 
@@ -541,6 +557,20 @@ void init() {
     }
 
     {
+      const env_var_t env("BUILDCACHE_REDIS_USERNAME");
+      if (env) {
+        s_redis_username = env.as_string();
+      }
+    }
+
+    {
+      const env_var_t env("BUILDCACHE_REDIS_PASSWORD");
+      if (env) {
+        s_redis_password = env.as_string();
+      }
+    }
+
+    {
       const env_var_t env("BUILDCACHE_REMOTE");
       if (env) {
         s_remote = env.as_string();
@@ -667,6 +697,14 @@ const std::string& prefix() {
 
 bool read_only() {
   return s_read_only;
+}
+
+const std::string& redis_username() {
+  return s_redis_username;
+}
+
+const std::string& redis_password() {
+  return s_redis_password;
 }
 
 bool read_only_remote() {

--- a/src/config/configuration.hpp
+++ b/src/config/configuration.hpp
@@ -123,6 +123,12 @@ bool read_only();
 /// @returns true if the remote cache is read only.
 bool read_only_remote();
 
+/// @returns the Redis ACL User Name for the remote cache.
+const std::string& redis_username();
+
+/// @returns the Redis Token/Password for the remote cache.
+const std::string& redis_password();
+
 /// @returns the remote cache service address.
 const std::string& remote();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -212,6 +212,10 @@ std::unique_ptr<bcache::program_wrapper_t> find_suitable_wrapper(
               << (bcache::config::read_only() ? "true" : "false") << "\n";
     std::cout << "  BUILDCACHE_READ_ONLY_REMOTE:       "
               << (bcache::config::read_only_remote() ? "true" : "false") << "\n";
+    std::cout << "  BUILDCACHE_REDIS_USERNAME:         " << bcache::config::redis_username()
+              << "\n";
+    std::cout << "  BUILDCACHE_REDIS_PASSWORD:         "
+              << (bcache::config::redis_password().empty() ? "" : "*******") << "\n";
     std::cout << "  BUILDCACHE_REMOTE:                 " << bcache::config::remote() << "\n";
     std::cout << "  BUILDCACHE_REMOTE_LOCKS:           "
               << (bcache::config::remote_locks() ? "true" : "false") << "\n";


### PR DESCRIPTION
Fixes https://github.com/mbitsnbites/buildcache/issues/40

Testing notes:
I pulled down the windows build artifact and swapped it into my build system - I have a large-ish C/C++ project that takes ~9 minutes to build on my machine with no cache, and ~1 minute to build with a local cache. I added `BUILDCACHE_REDIS_PASSWORD` and `BUILDCACHE_REMOTE` with my appropriate credentials for my authenticated redis server, and set `BUILDCACHE_DEBUG=1`. On my first build, I saw a whole lot of messages indicating that it was writing files to the remote cache; I also logged into my redis server and saw my `DBSIZE` steadily grow. Then I deleted my local cache and ran my build again and saw a lot of messages indicating it was downloading files - this run took ~4.5 minutes, which is right in between what it takes for a build with no cache and a build with a full local cache, which about matches my expectations.

Everything seems to be working as I expect