### PR TITLE
Link hiredis to OpenSSL when found

### DIFF
--- a/src/third_party/CMakeLists.txt
+++ b/src/third_party/CMakeLists.txt
@@ -192,6 +192,8 @@ if(MSVC)
 endif()
 if(WIN32 OR MINGW)
   target_link_libraries(hiredis PRIVATE ws2_32)
+elseif(OPENSSL_FOUND)
+  target_link_libraries(hiredis PRIVATE OpenSSL::SSL)
 endif()
 
 #---------------------------------------------------------------------------------------------------


### PR DESCRIPTION
On macOS, this fixes failing to locate `openssl/ssl.h` when using OpenSSL from a package manager (i.e. brew).