### PR TITLE
Msvc direct mode fix

### DIFF
--- a/src/wrappers/gcc_wrapper.hpp
+++ b/src/wrappers/gcc_wrapper.hpp
@@ -30,6 +30,10 @@ public:
 
   bool can_handle_command() override;
 
+  const string_list_t& get_resolved_args() override {
+    return m_resolved_args;
+  }
+
 protected:
   string_list_t get_capabilities() override;
   std::map<std::string, expected_file_t> get_build_files() override;

--- a/src/wrappers/msvc_wrapper.cpp
+++ b/src/wrappers/msvc_wrapper.cpp
@@ -129,18 +129,16 @@ string_list_t get_include_files(const std::string& std_err) {
 
   // Extract all unique include paths. Include path references in std_err start with the prefix
   // "Note: including file:", followed by one or more space characters, and finally the full path.
-  // In the regex wealso trim trailing whitespaces from the path, just for good measure.
   //
   // See: https://docs.microsoft.com/en-us/cpp/build/reference/showincludes-list-include-files
-  const std::regex incpath_re("\\s*Note: including file:\\s+(.*[^\\s])\\s*");
   std::set<std::string> includes;
+  constexpr char INCPATH_LINE[] = "Note: including file:";
+  constexpr size_t INCPATH_LINE_SIZE = sizeof(INCPATH_LINE);
   for (const auto& line : lines) {
-    std::smatch match;
-    if (std::regex_match(line, match, incpath_re)) {
-      if (match.size() == 2) {
-        const auto& include = match[1].str();
-        includes.insert(file::resolve_path(include));
-      }
+    size_t it = line.find(INCPATH_LINE);
+    if (it != std::string::npos) {
+      std::string include = strip(line.substr(it + INCPATH_LINE_SIZE));
+      includes.insert(file::resolve_path(include));
     }
   }
 

--- a/src/wrappers/msvc_wrapper.hpp
+++ b/src/wrappers/msvc_wrapper.hpp
@@ -30,6 +30,10 @@ public:
 
   bool can_handle_command() override;
 
+  const string_list_t& get_resolved_args() override {
+    return m_resolved_args;
+  }
+
 private:
   void resolve_args() override;
   string_list_t get_capabilities() override;

--- a/src/wrappers/program_wrapper.cpp
+++ b/src/wrappers/program_wrapper.cpp
@@ -120,8 +120,9 @@ bool program_wrapper_t::handle_command(int& return_code) {
           dm_hasher.inject_separator();
 
           // Hash the complete command line, as we need things like defines that are usually
-          // filtered by get_relevant_arguments().
-          dm_hasher.update(m_args);
+          // filtered by get_relevant_arguments(). Response files still need to be
+          // expanded so m_args cannot be used directly.
+          dm_hasher.update(get_resolved_args());
 
           // Hash all the input files.
           PERF_START(HASH_INPUT_FILES);

--- a/src/wrappers/program_wrapper.hpp
+++ b/src/wrappers/program_wrapper.hpp
@@ -48,6 +48,10 @@ public:
   /// @returns true if this wrapper can handle the command.
   virtual bool can_handle_command() = 0;
 
+  virtual const string_list_t& get_resolved_args() {
+    return m_args;
+  };
+
 protected:
   /// @brief A helper class for managing wrapper capabilities.
   class capabilities_t {

--- a/src/wrappers/ti_common_wrapper.hpp
+++ b/src/wrappers/ti_common_wrapper.hpp
@@ -28,6 +28,10 @@ class ti_common_wrapper_t : public program_wrapper_t {
 public:
   ti_common_wrapper_t(const file::exe_path_t& exe_path, const string_list_t& args);
 
+  const string_list_t& get_resolved_args() override {
+    return m_resolved_args;
+  }
+
 protected:
   void resolve_args() override;
   std::map<std::string, expected_file_t> get_build_files() override;


### PR DESCRIPTION
- Use resolved args for caching command line so that temporary response file does not always cause a cache miss
- Replace regex match for includes with std::find because std::regex seemed to be extremely slow in debug mode. When compiling a file which included a boost header, 97% of the execution time was spent parsing includes vs 67% with std::find. Overall compilation time in debug mode went from 25s to 10s which makes debugging nicer. A lot of time is still spent in utf8_to_ucs2 which is why I'm wondering why all windows file accesses use wide strings when there is the string version for the api functions. In e.g. below code snippet, the code behind !_WIN32 works on windows just fine.
```
std::string read(const std::string& path) {
  FILE* f;
  #ifdef _WIN32
    const auto err = _wfopen_s(&f, utf8_to_ucs2(path).c_str(), L"rb");
    if (err != 0) {
      throw std::runtime_error("Unable to open the file.");
    }
  #else
    f = std::fopen(path.c_str(), "rb");
    if (f == nullptr) {
      throw std::runtime_error("Unable to open the file.");
    }
  #endif
```
fixes #257 