### PR TITLE
base: fix C++ 20 compatibility

### DIFF
--- a/src/base/env_utils_test.cpp
+++ b/src/base/env_utils_test.cpp
@@ -51,8 +51,8 @@ TEST_CASE("Environment variable manipulation") {
 
   SUBCASE("Unicode names and values work") {
     // Define the variable.
-    const std::string name(u8"БуилдЦаче");
-    const std::string value(u8"είναι υπέροχο");
+    const std::string name(reinterpret_cast<const char*>(u8"БуилдЦаче"));
+    const std::string value(reinterpret_cast<const char*>(u8"είναι υπέροχο"));
     set_env(name, value);
 
     // The variable is defined.


### PR DESCRIPTION
Otherwise you'll compilation errors out with:
```
src/base/env_utils_test.cpp:54:41: error: no matching function for call to ‘std::__cxx11::basic_string<char>::basic_string(const char8_t [19])’
   54 |     const std::string name(u8"БуилдЦаче");
```

Looks like `char8_t*` is not convertible to `char*` in C++ 20.