### PR TITLE
CMake: Bump required version to 3.16

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@
 #  3. This notice may not be removed or altered from any source distribution.
 #---------------------------------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(BuildCache)
 
 # We build everything against the C++11 standard.


### PR DESCRIPTION
The CMake script apparently uses v3.14+ features. See:

https://github.com/mbitsnbites/buildcache/discussions/228

For reference, Ubuntu 18.04 ships with CMake v3.16.3.