### PR TITLE
Add a command line option (-d, --directory) to specify a custom location for the cache

### DIFF
--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -388,7 +388,7 @@ void init(const char* bcache_dir, bool force) {
 
   try {
     // Get the BuildCache home directory.
-    s_dir = bcache_dir ? std::string(bcache_dir) : get_dir();
+    s_dir = bcache_dir != nullptr ? std::string(bcache_dir) : get_dir();
 
     // Load any paramaters from the user configuration file.
     // Note: We do this before reading the configuration from the environment, so that the

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -378,17 +378,17 @@ std::string to_string(const compress_format_t format) {
   }
 }
 
-void init() {
+void init(const char* bcache_dir, bool force) {
   // Guard: Only initialize once.
   static bool s_initialized = false;
-  if (s_initialized) {
+  if (s_initialized && !force) {
     return;
   }
   s_initialized = true;
 
   try {
     // Get the BuildCache home directory.
-    s_dir = get_dir();
+    s_dir = bcache_dir ? std::string(bcache_dir) : get_dir();
 
     // Load any paramaters from the user configuration file.
     // Note: We do this before reading the configuration from the environment, so that the

--- a/src/config/configuration.hpp
+++ b/src/config/configuration.hpp
@@ -55,7 +55,7 @@ std::string to_string(const cache_accuracy_t accuracy);
 std::string to_string(const compress_format_t format);
 
 /// @brief Initialize the configuration based on environment variables etc.
-void init();
+void init(const char* bcache_dir = nullptr, bool force = false);
 
 /// @returns the BuildCache configuration file.
 const std::string& config_file();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -424,6 +424,9 @@ void print_help(const char* program_name) {
   std::cout << "    " << program_name << " compiler [compiler-options]\n";
   std::cout << "\n";
   std::cout << "Options:\n";
+  std::cout << "    -d, --directory PATH  operate on cache directory PATH instead of the default\n";
+  std::cout << "\n";
+  std::cout << "Commands:\n";
   std::cout << "    -C, --clear           clear the local cache (except configuration)\n";
   std::cout << "    -s, --show-stats      show statistics summary\n";
   std::cout << "    -c, --show-config     show current configuration\n";
@@ -472,8 +475,35 @@ int main(int argc, const char** argv) {
     std::exit(1);
   }
 
+  // Expected position for a BuildCache command
+  int argi = 1;
+
+  // If directory is the first argument, parse, re-initialize config and update the
+  // position of the optional BuildCache command. If directory is the second argument
+  // the first argument should be a BuildCache command, otherwise the directory was
+  // intended for a wrapped compiler and should be ignored.
+  if (compare_arg(argv[1], "-d", "--directory")) {
+    if (argc < 3 || argv[2][0] == '-') {
+      std::cerr << argv[0] << ": missing PATH for " << argv[1] << "\n";
+      print_help(argv[0]);
+      std::exit(1);
+    }
+    // Set the expected position for a BuildCache command
+    argi = 3;
+    // Re-initialize with the cache dir specified in the command line.
+    bcache::config::init(argv[2], true);
+  } else if (argc > 2 && compare_arg(argv[2], "-d", "--directory") && argv[1][0] == '-') {
+    if (argc < 4 || argv[3][0] == '-') {
+      std::cerr << argv[0] << ": missing PATH for " << argv[2] << "\n";
+      print_help(argv[0]);
+      std::exit(1);
+    }
+    // Re-initialize with the cache dir specified in the command line.
+    bcache::config::init(argv[3], true);
+  }
+
+  const std::string arg_str(argv[argi]);
   // Check if we are running any BuildCache commands.
-  const std::string arg_str(argv[1]);
   if (compare_arg(arg_str, "-C", "--clear")) {
     clear_cache_and_exit();
   } else if (compare_arg(arg_str, "-s", "--show-stats")) {
@@ -498,5 +528,5 @@ int main(int argc, const char** argv) {
   }
 
   // We got this far, so we're running as a compiler wrapper.
-  wrap_compiler_and_exit(argc - 1, &argv[1]);
+  wrap_compiler_and_exit(argc - argi, &argv[argi]);
 }


### PR DESCRIPTION
Add a command line option (-d, --directory) to specify a custom location for the cache as suggested in #264.