### PR TITLE
CI: Switch back to building on Ubuntu 20.04

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         config:
         - {
-            name: "Ubuntu 22.04 GCC",
-            os: ubuntu-22.04,
+            name: "Ubuntu 20.04 GCC",
+            os: ubuntu-20.04,
             shell: bash,
             cc: "gcc",
             cxx: "g++",
@@ -64,8 +64,8 @@ jobs:
             static_checks: true,
           }
         - {
-            name: "Ubuntu 20.04 GCC",
-            os: ubuntu-20.04,
+            name: "Ubuntu 22.04 GCC",
+            os: ubuntu-22.04,
             shell: bash,
             cc: "gcc",
             cxx: "g++",
@@ -184,7 +184,7 @@ jobs:
       matrix:
         config:
         - {
-            name: "Ubuntu 22.04 GCC",
+            name: "Ubuntu 20.04 GCC",
             artifact: "buildcache-linux.tar.gz",
             artifact_content_type: "application/gzip",
             os: ubuntu-latest


### PR DESCRIPTION
When running the Linux release binary on Ubuntu 20.04 you would get dynamic linking GLIBC version failures:

```
buildcache: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.29' not found
```

This hopefully fixes #291 .