### PR TITLE
hmac: Avoid out-of-bounds indexing

### DIFF
--- a/src/base/hmac.cpp
+++ b/src/base/hmac.cpp
@@ -315,7 +315,9 @@ std::string sha1_hmac(const std::string& key, const std::string& data) {
     // Concatenate inner_key_pad + data.
     std::vector<uint8_t> msg(inner_key_pad.size() + data.size());
     std::memcpy(msg.data(), inner_key_pad.data(), inner_key_pad.size());
-    std::memcpy(&msg[inner_key_pad.size()], data.data(), data.size());
+    if (!data.empty()) {
+      std::memcpy(&msg[inner_key_pad.size()], data.data(), data.size());
+    }
 
     // Calculate the inner hash.
     inner_hash = sha1(msg.data(), msg.size());


### PR DESCRIPTION
The out-of-bounds indexing was semantically harmless, but it would raise asserts in some STL implementations.

This fixes #296